### PR TITLE
CXL2.0: Fix few error from library

### DIFF
--- a/src/cxlmi/cxlmi.c
+++ b/src/cxlmi/cxlmi.c
@@ -750,10 +750,11 @@ static int send_ioctl_direct(struct cxlmi_endpoint *ep,
 				  cmd.retval);
 		return cmd.retval;
 	}
+	/* To make it compatible with CXL2.0, do not impose size check */
 	if (cmd.out.size < rsp_msg_sz_min - sizeof(*rsp_msg)) {
 		errno_save = errno;
-		cxlmi_msg(ctx, LOG_ERR, "ioctl returned too little data\n");
-		goto err;
+		cxlmi_msg(ctx, LOG_WARNING, "ioctl returned too little data\n");
+		//goto err;
 
 	}
 


### PR DESCRIPTION
1. Update the struture to remove event_log as it is input_payload for get_event_records (in both CXL2.0 and CXL3.0)
2. Remove restriction size check for response. As few new data fields are added in CXL3.1, CXL2.0 compliant devices fail when using this library
   * get_event_interrupt_policy
   * memdev_identify