### PR TITLE
Fix few error while running with CXL2.0 device

### DIFF
--- a/docs/Generic-Component-Commands.md
+++ b/docs/Generic-Component-Commands.md
@@ -157,13 +157,19 @@ The types of events can be any of:
 ## Get Event Records (0100h)
 
 This command shall retrieve as many event records from the
-event log that fit into the mailbox output payload (1Mb).
+event log that fit into the mailbox output payload (20 records).
 
+Input payload:
+
+   ```C
+struct cxlmi_cmd_get_event_records_req {
+	uint8_t event_log;
+};
+   ```
 Return payload:
 
    ```C
-struct cxlmi_cmd_get_event_records {
-	uint8_t event_log;
+struct cxlmi_cmd_get_event_records_rsp {
 	uint8_t flags;
 	uint8_t reserved1;
 	uint16_t overflow_err_count;
@@ -179,7 +185,8 @@ Command name:
    ```C
 int cxlmi_cmd_get_event_records(struct cxlmi_endpoint *ep,
 				struct cxlmi_tunnel_info *ti,
-				struct cxlmi_cmd_get_event_records *ret);
+				struct cxlmi_cmd_get_event_records_req *in,;
+				struct cxlmi_cmd_get_event_records_rsp *ret);
    ```
 
 ## Clear Event Records (0101h)

--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -71,8 +71,11 @@ struct cxlmi_event_record {
 } __attribute__((packed));
 
 /* CXL r3.1 Section 8.2.9.2.2: Get Event Records (Opcode 0100h) */
-struct cxlmi_cmd_get_event_records {
+struct cxlmi_cmd_get_event_records_req {
 	uint8_t event_log;
+} __attribute__((packed));
+
+struct cxlmi_cmd_get_event_records_rsp {
 	uint8_t flags;
 	uint8_t reserved1;
 	uint16_t overflow_err_count;

--- a/src/cxlmi/cxlmi.c
+++ b/src/cxlmi/cxlmi.c
@@ -750,11 +750,9 @@ static int send_ioctl_direct(struct cxlmi_endpoint *ep,
 				  cmd.retval);
 		return cmd.retval;
 	}
+	/* To make it compatible with CXL2.0, do not impose size check */
 	if (cmd.out.size < rsp_msg_sz_min - sizeof(*rsp_msg)) {
-		errno_save = errno;
-		cxlmi_msg(ctx, LOG_ERR, "ioctl returned too little data\n");
-		goto err;
-
+		cxlmi_msg(ctx, LOG_WARNING, "ioctl returned too little data\n");
 	}
 
 	return 0;

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -355,9 +355,11 @@ int cxlmi_cmd_set_response_msg_limit(struct cxlmi_endpoint *ep,
 int cxlmi_cmd_request_bg_op_abort(struct cxlmi_endpoint *ep,
 				  struct cxlmi_tunnel_info *ti);
 
+#define CXLMI_MAX_SUPPORTED_EVENT_RECORDS 20
 int cxlmi_cmd_get_event_records(struct cxlmi_endpoint *ep,
 				struct cxlmi_tunnel_info *ti,
-				struct cxlmi_cmd_get_event_records *ret);
+				struct cxlmi_cmd_get_event_records_req *in,
+				struct cxlmi_cmd_get_event_records_rsp *ret);
 int cxlmi_cmd_clear_event_records(struct cxlmi_endpoint *ep,
 				  struct cxlmi_tunnel_info *ti,
 				  struct cxlmi_cmd_clear_event_records *in);


### PR DESCRIPTION
    CXL2.0: Fix few error from library
    
    1. Update the structure to remove event_log as it is input_payload for
       get_event_records (in both CXL2.0 and CXL3.0)

    CXL2.0: Fix few APIs from library for CXL2.0
    
    1. Remove restriction size check for response. As few new data fields
       are added in CXL3.1, CXL2.0 compliant devices fail when using this library
       * get_event_interrupt_policy
       * memdev_identify
