### PR TITLE
CXL2.0: Fix the payloads for CXL 2.0 compatibility

### DIFF
--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -101,7 +101,9 @@ struct cxlmi_cmd_get_event_interrupt_policy {
 	uint8_t warning_settings;
 	uint8_t failure_settings;
 	uint8_t fatal_settings;
+#ifndef SUPPORT_CXL_2_0
 	uint8_t dcd_settings;
+#endif
 } __attribute__((packed));
 
 /* CXL r3.1 Section 8.2.9.2.5: Set Event Interrupt Policy (Opcode 0103h) */
@@ -110,7 +112,9 @@ struct cxlmi_cmd_set_event_interrupt_policy {
 	uint8_t warning_settings;
 	uint8_t failure_settings;
 	uint8_t fatal_settings;
+#ifndef SUPPORT_CXL_2_0
 	uint8_t dcd_settings;
+#endif
 } __attribute__((packed));
 
 /* CXL r3.1 Section 8.2.9.2.6: Get MCTP Event Interrupt Policy (Opcode 0104h) */
@@ -245,7 +249,9 @@ struct cxlmi_cmd_memdev_identify {
 	uint16_t inject_poison_limit;
 	uint8_t poison_caps;
 	uint8_t qos_telemetry_caps;
+#ifndef SUPPORT_CXL_2_0
 	uint16_t dc_event_log_size;
+#endif
 } __attribute__((packed));
 
 /* CXL r3.1 Section 8.2.9.9.2.1: Get Partition Info (Opcode 4100h) */

--- a/src/cxlmi/commands.c
+++ b/src/cxlmi/commands.c
@@ -242,7 +242,11 @@ cxlmi_cmd_get_event_interrupt_policy(struct cxlmi_endpoint *ep,
 	ssize_t rsp_sz;
 	int rc;
 
+#ifndef SUPPORT_CXL_2_0
 	CXLMI_BUILD_BUG_ON(sizeof(*ret) != 5);
+#else
+	CXLMI_BUILD_BUG_ON(sizeof(*ret) != 4);
+#endif
 
 	arm_cci_request(ep, &req, 0, EVENTS, GET_EVENT_IRQ_POL);
 
@@ -260,7 +264,9 @@ cxlmi_cmd_get_event_interrupt_policy(struct cxlmi_endpoint *ep,
 	ret->warning_settings = rsp_pl->warning_settings;
 	ret->failure_settings = rsp_pl->failure_settings;
 	ret->fatal_settings = rsp_pl->fatal_settings;
+#ifndef SUPPORT_CXL_2_0
 	ret->dcd_settings = rsp_pl->dcd_settings;
+#endif
 
 	return rc;
 }
@@ -276,7 +282,11 @@ cxlmi_cmd_set_event_interrupt_policy(struct cxlmi_endpoint *ep,
 	size_t req_sz;
 	int rc = 0;
 
+#ifndef SUPPORT_CXL_2_0
 	CXLMI_BUILD_BUG_ON(sizeof(*in) != 5);
+#else
+	CXLMI_BUILD_BUG_ON(sizeof(*in) != 4);
+#endif
 
 	req_sz = sizeof(*req) + sizeof(*in);
 	req = calloc(1, req_sz);
@@ -290,7 +300,9 @@ cxlmi_cmd_set_event_interrupt_policy(struct cxlmi_endpoint *ep,
 	req_pl->warning_settings = in->warning_settings;
 	req_pl->failure_settings = in->failure_settings;
 	req_pl->fatal_settings = in->fatal_settings;
+#ifndef SUPPORT_CXL_2_0
 	req_pl->dcd_settings = in->dcd_settings;
+#endif
 
 	rc = send_cmd_cci(ep, ti, req, req_sz, &rsp, sizeof(rsp), sizeof(rsp));
 	return rc;
@@ -798,7 +810,11 @@ CXLMI_EXPORT int cxlmi_cmd_memdev_identify(struct cxlmi_endpoint *ep,
 	int rc;
 	ssize_t rsp_sz;
 
+#ifndef SUPPORT_CXL_2_0
 	CXLMI_BUILD_BUG_ON(sizeof(*ret) != 0x45);
+#else
+	CXLMI_BUILD_BUG_ON(sizeof(*ret) != 0x43);
+#endif
 
 	arm_cci_request(ep, &req, 0, IDENTIFY, MEMORY_DEVICE);
 
@@ -832,7 +848,9 @@ CXLMI_EXPORT int cxlmi_cmd_memdev_identify(struct cxlmi_endpoint *ep,
 	ret->inject_poison_limit = le16_to_cpu(rsp_pl->inject_poison_limit);
 	ret->poison_caps = rsp_pl->poison_caps;
 	ret->qos_telemetry_caps = rsp_pl->qos_telemetry_caps;
+#ifndef SUPPORT_CXL_2_0
 	ret->dc_event_log_size = le16_to_cpu(rsp_pl->dc_event_log_size);
+#endif
 
 	return rc;
 }


### PR DESCRIPTION
1. Few commads are updated in payload size (input or output) in CXL3.1
2. memdev_identify(opcode 0x4000) has new modification in CXL 3.1
3. Get/Set event interrupt policy (opcode 0x102 and 0x103 respectively) introduced a new byte in output and input payload
4. If any system needs CXL 2.0 support, they can still resuse this library by giving `-DSUPPORT_CXL_2_0` in meson.build project args