### PR TITLE
FMAPI DCD Management Commands (5600h-5608h)

### DIFF
--- a/docs/FM-API.md
+++ b/docs/FM-API.md
@@ -23,7 +23,8 @@ command set, as per the latest specification.
    * [Set QoS Allocated BW (5407h)](#set-qos-allocated-bw-5407h)
    * [Get QoS BW Limit (5408h)](#get-qos-bw-limit-5408h)
    * [Set QoS BW Limit (5409h)](#set-qos-bw-limit-5409h)
-
+* [FMAPI DCD Management (56h)](#fmapi-dcd-management-56h)
+	* [Get DCD Info (5600h)](#get-dcd-info-5600h)
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 <!-- Added by: dave, at: Mon Aug 19 01:13:48 PM PDT 2024 -->
 
@@ -513,4 +514,33 @@ int cxlmi_cmd_fmapi_set_qos_bw_limit(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_set_qos_bw_limit *in,
 			struct cxlmi_cmd_fmapi_set_qos_bw_limit *ret);
+   ```
+
+# FMAPI DCD Management (56h)
+
+## Get DCD Info (5600h)
+
+Return payload:
+
+   ```C
+struct cxlmi_cmd_fmapi_get_dcd_info {
+	uint8_t num_hosts;
+	uint8_t num_supported_dc_regions;
+	uint8_t rsvd1[0x2];
+	uint16_t capacity_selection_policies;
+	uint8_t rsvd2[0x2];
+	uint16_t capacity_removal_policies;
+	uint8_t sanitize_on_release_config_mask;
+	uint8_t rsvd3;
+	uint64_t total_dynamic_capacity;
+	uint64_t supported_block_sizes[8];
+};
+   ```
+
+Command name:
+
+   ```C
+int cxlmi_cmd_fmapi_get_dcd_info(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_get_dcd_info *ret);
    ```

--- a/docs/FM-API.md
+++ b/docs/FM-API.md
@@ -28,6 +28,7 @@ command set, as per the latest specification.
 	* [Get Host DC Region Config (5601h)](#get-host-dc-region-config-5601h)
 	* [Set DC Region Config (5602h)](#set-host-dc-region-config-5602h)
 	* [Get DC Region Extent List (5603h)](#get-dc-region-extent-lists-5603h)
+	* [Initiate DC Add (5604h)](#initiate-dc-add-5604h)
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 <!-- Added by: dave, at: Mon Aug 19 01:13:48 PM PDT 2024 -->
 
@@ -651,4 +652,32 @@ int cxlmi_cmd_fmapi_get_dc_region_ext_list(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_get_dc_region_ext_list_req *in,
 			struct cxlmi_cmd_fmapi_get_dc_region_ext_list_rsp *ret);
+   ```
+
+## Initiate DC Add (5604h)
+Input Payload:
+```C
+struct cxlmi_cmd_fmapi_initiate_dc_add_req {
+	uint16_t host_id;
+	uint8_t selection_policy;
+	uint8_t region_num;
+	uint64_t length;
+	uint8_t tag[0x10];
+	uint32_t ext_count;
+	struct {
+	       uint64_t start_dpa;
+	       uint64_t len;
+	       uint8_t tag[0x10];
+	       uint16_t shared_seq;
+	       uint8_t rsvd[0x6];
+       } extents[];
+};
+```
+
+Command name:
+
+   ```C
+int cxlmi_cmd_fmapi_initiate_dc_add(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_initiate_dc_add_req *in);
    ```

--- a/docs/FM-API.md
+++ b/docs/FM-API.md
@@ -29,6 +29,7 @@ command set, as per the latest specification.
 	* [Set DC Region Config (5602h)](#set-host-dc-region-config-5602h)
 	* [Get DC Region Extent List (5603h)](#get-dc-region-extent-lists-5603h)
 	* [Initiate DC Add (5604h)](#initiate-dc-add-5604h)
+	* [Initiate DC Release (5605h)](#initiate-dc-release-5605h)
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 <!-- Added by: dave, at: Mon Aug 19 01:13:48 PM PDT 2024 -->
 
@@ -681,3 +682,32 @@ int cxlmi_cmd_fmapi_initiate_dc_add(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_initiate_dc_add_req *in);
    ```
+
+## Initiate DC Release (5605h)
+Input Payload:
+```C
+struct cxlmi_cmd_fmapi_initiate_dc_release_req {
+	uint16_t host_id;
+	uint8_t flags;
+	uint8_t rsvd;
+	uint64_t length;
+	uint8_t tag[0x10];
+	uint32_t ext_count;
+	struct {
+	       uint64_t start_dpa;
+	       uint64_t len;
+	       uint8_t tag[0x10];
+	       uint16_t shared_seq;
+	       uint8_t rsvd[0x6];
+       } extents[];
+};
+```
+
+Command name:
+
+   ```C
+int cxlmi_cmd_fmapi_initiate_dc_release(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_initiate_dc_release_req *in);
+   ```
+

--- a/docs/FM-API.md
+++ b/docs/FM-API.md
@@ -30,6 +30,7 @@ command set, as per the latest specification.
 	* [Get DC Region Extent List (5603h)](#get-dc-region-extent-lists-5603h)
 	* [Initiate DC Add (5604h)](#initiate-dc-add-5604h)
 	* [Initiate DC Release (5605h)](#initiate-dc-release-5605h)
+	* [DC Add Reference (5606h)](#dc-add-reference-5606h)
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 <!-- Added by: dave, at: Mon Aug 19 01:13:48 PM PDT 2024 -->
 
@@ -709,5 +710,21 @@ Command name:
 int cxlmi_cmd_fmapi_initiate_dc_release(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_initiate_dc_release_req *in);
+   ```
+
+## DC Add Reference (5606h)
+Input Payload:
+```C
+struct cxlmi_cmd_fmapi_dc_add_ref_req {
+	uint8_t tag[0x10];
+};
+```
+
+Command name:
+
+   ```C
+int cxlmi_cmd_fmapi_dc_add_reference(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_dc_add_ref_req *in);
    ```
 

--- a/docs/FM-API.md
+++ b/docs/FM-API.md
@@ -26,6 +26,7 @@ command set, as per the latest specification.
 * [FMAPI DCD Management (56h)](#fmapi-dcd-management-56h)
 	* [Get DCD Info (5600h)](#get-dcd-info-5600h)
 	* [Get Host DC Region Config (5601h)](#get-host-dc-region-config-5601h)
+	* [Set DC Region Config (5602h)](#set-host-dc-region-config-5602h)
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 <!-- Added by: dave, at: Mon Aug 19 01:13:48 PM PDT 2024 -->
 
@@ -590,4 +591,23 @@ int cxlmi_cmd_fmapi_get_dc_reg_config(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_get_host_dc_reg_config_req *in,
 			struct cxlmi_cmd_fmapi_get_host_dc_reg_config_rsp *ret);
+   ```
+
+## Set Host DC Region Config (5602h)
+Input Payload:
+```C
+struct cxlmi_cmd_fmapi_set_dc_region_config {
+	uint8_t region_id;
+	uint8_t rsvd[3];
+	uint64_t block_sz;
+	uint8_t sanitize_on_release;
+	uint8_t rsvd2[3];
+};
+```
+
+Command name:
+   ```C
+int cxlmi_cmd_fmapi_set_dc_region_config(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_set_dc_region_config *in);
    ```

--- a/docs/FM-API.md
+++ b/docs/FM-API.md
@@ -27,6 +27,7 @@ command set, as per the latest specification.
 	* [Get DCD Info (5600h)](#get-dcd-info-5600h)
 	* [Get Host DC Region Config (5601h)](#get-host-dc-region-config-5601h)
 	* [Set DC Region Config (5602h)](#set-host-dc-region-config-5602h)
+	* [Get DC Region Extent List (5603h)](#get-dc-region-extent-lists-5603h)
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 <!-- Added by: dave, at: Mon Aug 19 01:13:48 PM PDT 2024 -->
 
@@ -610,4 +611,44 @@ Command name:
 int cxlmi_cmd_fmapi_set_dc_region_config(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_set_dc_region_config *in);
+   ```
+
+## Get DC Region Extent Lists (5603h)
+Input Payload:
+```C
+struct cxlmi_cmd_fmapi_get_dc_region_ext_list_req {
+	uint16_t host_id;
+	uint8_t rsvd[2];
+	uint32_t extent_count;
+	uint32_t start_ext_index;
+};
+```
+Return Payload:
+
+   ```C
+struct cxlmi_cmd_fmapi_get_dc_region_ext_list_rsp {
+	uint16_t host_id;
+	uint8_t rsvd1[2];
+	uint32_t start_ext_index;
+	uint32_t extents_returned;
+	uint32_t total_extents;
+	uint32_t list_generation_num;
+	uint8_t rsvd2[4];
+	struct {
+	       uint64_t start_dpa;
+	       uint64_t len;
+	       uint8_t tag[0x10];
+	       uint16_t shared_seq;
+	       uint8_t rsvd[0x6];
+       } extents[];
+};
+   ```
+
+Command name:
+
+   ```C
+int cxlmi_cmd_fmapi_get_dc_region_ext_list(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_get_dc_region_ext_list_req *in,
+			struct cxlmi_cmd_fmapi_get_dc_region_ext_list_rsp *ret);
    ```

--- a/docs/FM-API.md
+++ b/docs/FM-API.md
@@ -25,6 +25,7 @@ command set, as per the latest specification.
    * [Set QoS BW Limit (5409h)](#set-qos-bw-limit-5409h)
 * [FMAPI DCD Management (56h)](#fmapi-dcd-management-56h)
 	* [Get DCD Info (5600h)](#get-dcd-info-5600h)
+	* [Get Host DC Region Config (5601h)](#get-host-dc-region-config-5601h)
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 <!-- Added by: dave, at: Mon Aug 19 01:13:48 PM PDT 2024 -->
 
@@ -543,4 +544,50 @@ Command name:
 int cxlmi_cmd_fmapi_get_dcd_info(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_get_dcd_info *ret);
+   ```
+
+## Get Host DC Region Config (5601h)
+Note that the returned number of DC region configurations
+is limited by the library to 8. This is because of the
+change of payload size in newer versions of the specification.
+
+Input Payload:
+```C
+struct cxlmi_cmd_fmapi_get_host_dc_reg_config_req {
+	uint16_t host_id;
+	uint8_t region_cnt;
+	uint8_t start_region_id;
+};
+```
+Return Payload:
+
+   ```C
+struct cxlmi_cmd_fmapi_get_host_dc_reg_config_rsp {
+	uint16_t host_id;
+	uint8_t num_regions;
+	uint8_t regions_returned;
+	struct {
+		uint64_t base;
+		uint64_t decode_len;
+		uint64_t region_len;
+		uint64_t block_size;
+		uint8_t flags;
+		uint8_t rsvd[3];
+		uint8_t sanitize_on_release;
+		uint8_t rsvd2[3];
+	} region_configs[8];
+	uint32_t num_extents_supported;
+	uint32_t num_extents_available;
+	uint32_t num_tags_supported;
+	uint32_t num_tags_available;
+};
+   ```
+
+Command name:
+
+   ```C
+int cxlmi_cmd_fmapi_get_dc_reg_config(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_get_host_dc_reg_config_req *in,
+			struct cxlmi_cmd_fmapi_get_host_dc_reg_config_rsp *ret);
    ```

--- a/docs/FM-API.md
+++ b/docs/FM-API.md
@@ -32,6 +32,7 @@ command set, as per the latest specification.
 	* [Initiate DC Release (5605h)](#initiate-dc-release-5605h)
 	* [DC Add Reference (5606h)](#dc-add-reference-5606h)
 	* [DC Remove Reference (5607h)](#dc-remove-reference-5607h)
+	* [DC List Tags (5608h)](#dc-list-tags-5608h)
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 <!-- Added by: dave, at: Mon Aug 19 01:13:48 PM PDT 2024 -->
 
@@ -743,4 +744,42 @@ Command name:
 int cxlmi_cmd_fmapi_dc_remove_reference(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_dc_remove_ref_req *in);
+   ```
+
+
+## DC List Tags (5608h)
+Input Payload:
+
+   ```C
+struct cxlmi_cmd_fmapi_dc_list_tags_req {
+	uint32_t start_ind;
+	uint32_t max_tags;
+};
+   ```
+
+Output Payload:
+   ```C
+struct cxlmi_cmd_fmapi_dc_list_tags_rsp {
+	uint32_t generation_num;
+	uint32_t total_num_tags;
+	uint32_t num_tags_returned;
+	uint8_t validity_bitmap;
+	uint8_t rsvd[3];
+	struct {
+		uint8_t tag[0x10];
+		uint8_t flags;
+		uint8_t rsvd[3];
+		uint8_t ref_bitmap[32];
+		uint8_t pending_ref_bitmap[32];
+	} tags_list[];
+};
+   ```
+
+Command name:
+
+   ```C
+int cxlmi_cmd_fmapi_dc_list_tags(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_dc_list_tags_req *in,
+			struct cxlmi_cmd_fmapi_dc_list_tags_rsp *ret);
    ```

--- a/docs/FM-API.md
+++ b/docs/FM-API.md
@@ -31,6 +31,7 @@ command set, as per the latest specification.
 	* [Initiate DC Add (5604h)](#initiate-dc-add-5604h)
 	* [Initiate DC Release (5605h)](#initiate-dc-release-5605h)
 	* [DC Add Reference (5606h)](#dc-add-reference-5606h)
+	* [DC Remove Reference (5607h)](#dc-remove-reference-5607h)
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 <!-- Added by: dave, at: Mon Aug 19 01:13:48 PM PDT 2024 -->
 
@@ -728,3 +729,18 @@ int cxlmi_cmd_fmapi_dc_add_reference(struct cxlmi_endpoint *ep,
 			struct cxlmi_cmd_fmapi_dc_add_ref_req *in);
    ```
 
+## DC Remove Reference (5607h)
+Input Payload:
+```C
+struct cxlmi_cmd_fmapi_dc_remove_ref_req {
+	uint8_t tag[0x10];
+};
+```
+
+Command name:
+
+   ```C
+int cxlmi_cmd_fmapi_dc_remove_reference(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_dc_remove_ref_req *in);
+   ```

--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -766,4 +766,14 @@ struct cxlmi_cmd_fmapi_get_host_dc_region_config_rsp {
 	uint32_t num_tags_supported;
 	uint32_t num_tags_available;
 }__attribute__((packed));
+
+/* CXL r3.2 Section 7.6.7.6.3 Set DC Region Configuration (Opcode 5602h) */
+struct cxlmi_cmd_fmapi_set_dc_region_config {
+	uint8_t region_id;
+	uint8_t rsvd[3];
+	uint64_t block_sz;
+	uint8_t sanitize_on_release;
+	uint8_t rsvd2[3];
+}__attribute__((packed));
+
 #endif

--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -835,4 +835,9 @@ struct cxlmi_cmd_fmapi_initiate_dc_release_req {
        } __attribute__((packed)) extents[];
 }__attribute__((packed));
 
+/* CXL r3.2 Section 7.6.7.6.7 Dynamic Capacity Add Reference (Opcode 5606h) */
+struct cxlmi_cmd_fmapi_dc_add_ref {
+	uint8_t tag[0x10];
+}__attribute__((packed));
+
 #endif

--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -818,4 +818,21 @@ struct cxlmi_cmd_fmapi_initiate_dc_add_req {
        } __attribute__((packed)) extents[];
 }__attribute__((packed));
 
+/* CXL r3.2 Section 7.6.7.6.6 Initiate Dynamic Capacity Release (Opcode 5605h) */
+struct cxlmi_cmd_fmapi_initiate_dc_release_req {
+	uint16_t host_id;
+	uint8_t flags;
+	uint8_t rsvd;
+	uint64_t length;
+	uint8_t tag[0x10];
+	uint32_t ext_count;
+	struct {
+	       uint64_t start_dpa;
+	       uint64_t len;
+	       uint8_t tag[0x10];
+	       uint16_t shared_seq;
+	       uint8_t rsvd[6];
+       } __attribute__((packed)) extents[];
+}__attribute__((packed));
+
 #endif

--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -776,4 +776,29 @@ struct cxlmi_cmd_fmapi_set_dc_region_config {
 	uint8_t rsvd2[3];
 }__attribute__((packed));
 
+/* CXL r3.2 Section 7.6.7.6.4 Get DC Region Extent Lists (Opcode 5603h) */
+struct cxlmi_cmd_fmapi_get_dc_region_ext_list_req {
+	uint16_t host_id;
+	uint8_t rsvd[2];
+	uint32_t extent_count;
+	uint32_t start_ext_index;
+}__attribute__((packed));
+
+struct cxlmi_cmd_fmapi_get_dc_region_ext_list_rsp {
+	uint16_t host_id;
+	uint8_t rsvd1[2];
+	uint32_t start_ext_index;
+	uint32_t extents_returned;
+	uint32_t total_extents;
+	uint32_t list_generation_num;
+	uint8_t rsvd2[4];
+	struct {
+	       uint64_t start_dpa;
+	       uint64_t len;
+	       uint8_t tag[0x10];
+	       uint16_t shared_seq;
+	       uint8_t rsvd[6];
+       } __attribute__((packed)) extents[];
+}__attribute__((packed));
+
 #endif

--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -739,4 +739,31 @@ struct cxlmi_cmd_fmapi_get_dcd_info {
 	uint64_t region_7_supported_blk_sz_mask;
 } __attribute__((packed));
 
+/* CXL r3.2 7.6.7.6.2 Get Host DC Region Configuration (Opcode 5601h) */
+/* Note: The region configs structure array is fixed to hold 8 regions */
+struct cxlmi_cmd_fmapi_get_host_dc_region_config_req {
+	uint16_t host_id;
+	uint8_t region_cnt;
+	uint8_t start_region_id;
+}__attribute__((packed));
+
+struct cxlmi_cmd_fmapi_get_host_dc_region_config_rsp {
+	uint16_t host_id;
+	uint8_t num_regions;
+	uint8_t regions_returned;
+	struct {
+		uint64_t base;
+		uint64_t decode_len;
+		uint64_t region_len;
+		uint64_t block_size;
+		uint8_t flags;
+		uint8_t rsvd[3];
+		uint8_t sanitize_on_release;
+		uint8_t rsvd2[3];
+	} __attribute__((packed)) region_configs[8];
+	uint32_t num_extents_supported;
+	uint32_t num_extents_available;
+	uint32_t num_tags_supported;
+	uint32_t num_tags_available;
+}__attribute__((packed));
 #endif

--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -845,4 +845,25 @@ struct cxlmi_cmd_fmapi_dc_remove_ref {
 	uint8_t tag[0x10];
 }__attribute__((packed));
 
+/* CXL r3.2 Section 7.6.7.6.9 Dynamic Capacity List Tags (Opcode 5608h) */
+struct cxlmi_cmd_fmapi_dc_list_tags_req {
+	uint32_t start_idx;
+	uint32_t tags_count;
+}__attribute__((packed));
+
+struct cxlmi_cmd_fmapi_dc_list_tags_rsp {
+	uint32_t generation_num;
+	uint32_t total_num_tags;
+	uint32_t num_tags_returned;
+	uint8_t validity_bitmap;
+	uint8_t rsvd[3];
+	struct {
+		uint8_t tag[0x10];
+		uint8_t flags;
+		uint8_t rsvd[3];
+		uint8_t ref_bitmap[0x20];
+		uint8_t pending_ref_bitmap[0x20];
+	} __attribute__((packed)) tags_list[];
+}__attribute__((packed));
+
 #endif

--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -715,4 +715,28 @@ struct cxlmi_cmd_fmapi_set_qos_bw_limit {
 	uint8_t start_ld_id;
 	uint8_t qos_limit_fraction[];
 } __attribute__((packed));
+
+/* CXL r3.2 Section 7.6.7.6.1: Get DCD Info (Opcode 5600h) */
+struct cxlmi_cmd_fmapi_get_dcd_info {
+	uint8_t num_hosts;
+	uint8_t num_supported_dc_regions;
+	uint8_t rsvd1[0x2];
+	uint16_t capacity_selection_policies;
+	uint8_t rsvd2[0x2];
+	uint16_t capacity_removal_policies;
+	uint8_t sanitize_on_release_config_mask;
+	uint8_t rsvd3;
+	/* Multiple of 256MB */
+	uint64_t total_dynamic_capacity;
+	/* region_x_blk_sz_mask only valid if x < num_supported_dc_regions */
+	uint64_t region_0_supported_blk_sz_mask;
+	uint64_t region_1_supported_blk_sz_mask;
+	uint64_t region_2_supported_blk_sz_mask;
+	uint64_t region_3_supported_blk_sz_mask;
+	uint64_t region_4_supported_blk_sz_mask;
+	uint64_t region_5_supported_blk_sz_mask;
+	uint64_t region_6_supported_blk_sz_mask;
+	uint64_t region_7_supported_blk_sz_mask;
+} __attribute__((packed));
+
 #endif

--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -801,4 +801,21 @@ struct cxlmi_cmd_fmapi_get_dc_region_ext_list_rsp {
        } __attribute__((packed)) extents[];
 }__attribute__((packed));
 
+/* CXL r3.1 Section 7.6.7.6.5 Initiate Dynamic Capacity Add (Opcode 5604h) */
+struct cxlmi_cmd_fmapi_initiate_dc_add_req {
+	uint16_t host_id;
+	uint8_t selection_policy;
+	uint8_t region_num;
+	uint64_t length;
+	uint8_t tag[0x10];
+	uint32_t ext_count;
+	struct {
+	       uint64_t start_dpa;
+	       uint64_t len;
+	       uint8_t tag[0x10];
+	       uint16_t shared_seq;
+	       uint8_t rsvd[6];
+       } __attribute__((packed)) extents[];
+}__attribute__((packed));
+
 #endif

--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -840,4 +840,9 @@ struct cxlmi_cmd_fmapi_dc_add_ref {
 	uint8_t tag[0x10];
 }__attribute__((packed));
 
+/* CXL r3.2 Section 7.6.7.6.8 Dynamic Capacity Remove Reference (Opcode 5607h) */
+struct cxlmi_cmd_fmapi_dc_remove_ref {
+	uint8_t tag[0x10];
+}__attribute__((packed));
+
 #endif

--- a/src/cxlmi/commands.c
+++ b/src/cxlmi/commands.c
@@ -2829,6 +2829,34 @@ CXLMI_EXPORT int cxlmi_cmd_fmapi_dc_add_reference(struct cxlmi_endpoint *ep,
 	return send_cmd_cci(ep, ti, req, req_sz, rsp, rsp_sz, rsp_sz);
 }
 
+CXLMI_EXPORT int cxlmi_cmd_fmapi_dc_remove_reference(struct cxlmi_endpoint *ep,
+				struct cxlmi_tunnel_info *ti,
+				struct cxlmi_cmd_fmapi_dc_remove_ref *in)
+{
+	struct cxlmi_cmd_fmapi_dc_remove_ref *req_pl;
+	_cleanup_free_ struct cxlmi_cci_msg *req = NULL;
+	_cleanup_free_ struct cxlmi_cci_msg *rsp = NULL;
+	size_t req_sz, rsp_sz;
+
+	CXLMI_BUILD_BUG_ON(sizeof(*in) != 0x10);
+
+	req_sz = sizeof(*req) + sizeof(*req_pl);
+	req = calloc(1, req_sz);
+	if(!req)
+		return -1;
+
+	arm_cci_request(ep, req, sizeof(*req_pl), DCD_MANAGEMENT, DC_REMOVE_REFERENCE);
+	req_pl = (struct cxlmi_cmd_fmapi_dc_remove_ref *)req->payload;
+	memcpy(req_pl->tag, in->tag, 0x10);
+
+	rsp_sz = sizeof(*rsp);
+	rsp = calloc(1, rsp_sz);
+	if (!rsp)
+		return -1;
+
+	return send_cmd_cci(ep, ti, req, req_sz, rsp, rsp_sz, rsp_sz);
+}
+
 CXLMI_EXPORT int cxlmi_cmd_memdev_get_dc_config(struct cxlmi_endpoint *ep,
 		struct cxlmi_tunnel_info *ti,
 		struct cxlmi_cmd_memdev_get_dc_config_req *in,

--- a/src/cxlmi/commands.c
+++ b/src/cxlmi/commands.c
@@ -2801,6 +2801,34 @@ CXLMI_EXPORT int cxlmi_cmd_fmapi_initiate_dc_release(struct cxlmi_endpoint *ep,
 	return send_cmd_cci(ep, ti, req, req_sz, rsp, rsp_sz, rsp_sz);
 }
 
+CXLMI_EXPORT int cxlmi_cmd_fmapi_dc_add_reference(struct cxlmi_endpoint *ep,
+				struct cxlmi_tunnel_info *ti,
+				struct cxlmi_cmd_fmapi_dc_add_ref *in)
+{
+	struct cxlmi_cmd_fmapi_dc_add_ref *req_pl;
+	_cleanup_free_ struct cxlmi_cci_msg *req = NULL;
+	_cleanup_free_ struct cxlmi_cci_msg *rsp = NULL;
+	size_t req_sz, rsp_sz;
+
+	CXLMI_BUILD_BUG_ON(sizeof(*in) != 0x10);
+
+	req_sz = sizeof(*req) + sizeof(*req_pl);
+	req = calloc(1, req_sz);
+	if(!req)
+		return -1;
+
+	arm_cci_request(ep, req, sizeof(*req_pl), DCD_MANAGEMENT, DC_ADD_REFERENCE);
+	req_pl = (struct cxlmi_cmd_fmapi_dc_add_ref *)req->payload;
+	memcpy(req_pl->tag, in->tag, 0x10);
+
+	rsp_sz = sizeof(*rsp);
+	rsp = calloc(1, rsp_sz);
+	if (!rsp)
+		return -1;
+
+	return send_cmd_cci(ep, ti, req, req_sz, rsp, rsp_sz, rsp_sz);
+}
+
 CXLMI_EXPORT int cxlmi_cmd_memdev_get_dc_config(struct cxlmi_endpoint *ep,
 		struct cxlmi_tunnel_info *ti,
 		struct cxlmi_cmd_memdev_get_dc_config_req *in,

--- a/src/cxlmi/commands.c
+++ b/src/cxlmi/commands.c
@@ -2724,6 +2724,45 @@ CXLMI_EXPORT int cxlmi_cmd_fmapi_get_dc_region_ext_list(struct cxlmi_endpoint *e
 	return rc;
 }
 
+CXLMI_EXPORT int cxlmi_cmd_fmapi_initiate_dc_add(struct cxlmi_endpoint *ep,
+				struct cxlmi_tunnel_info *ti,
+				struct cxlmi_cmd_fmapi_initiate_dc_add_req *in)
+{
+	struct cxlmi_cmd_fmapi_initiate_dc_add_req *req_pl;
+	_cleanup_free_ struct cxlmi_cci_msg *req = NULL;
+	_cleanup_free_ struct cxlmi_cci_msg *rsp = NULL;
+	size_t req_sz, rsp_sz;
+	int i, ext_list_sz;
+
+	ext_list_sz = in->ext_count * sizeof(*in->extents);
+	req_sz = sizeof(*req) + sizeof(*in) + ext_list_sz;
+	req = calloc(1, req_sz);
+	if (!req)
+		return -1;
+
+	arm_cci_request(ep, req, sizeof(*in), DCD_MANAGEMENT, INITIATE_DC_ADD);
+	req_pl = (struct cxlmi_cmd_fmapi_initiate_dc_add_req *)req->payload;
+	req_pl->host_id = cpu_to_le16(in->host_id);
+	req_pl->selection_policy = in->selection_policy;
+	req_pl->region_num = in->region_num;
+	req_pl->length = cpu_to_le64(in->length);
+	memcpy(req_pl->tag, in->tag, 0x10);
+	req_pl->ext_count = cpu_to_le32(in->ext_count);
+
+	for (i = 0; i < in->ext_count; i++) {
+		req_pl->extents[i].start_dpa = cpu_to_le64(in->extents[i].start_dpa);
+		req_pl->extents[i].len = cpu_to_le64(in->extents[i].len);
+		memcpy(req_pl->tag, in->tag, 0x10);
+		req_pl->extents[i].shared_seq = cpu_to_le16(in->extents[i].shared_seq);
+	}
+
+	rsp_sz = sizeof(*rsp);
+	rsp = calloc(1, rsp_sz);
+	if (!rsp)
+		return -1;
+	return send_cmd_cci(ep, ti, req, req_sz, rsp, rsp_sz, rsp_sz);
+}
+
 CXLMI_EXPORT int cxlmi_cmd_memdev_get_dc_config(struct cxlmi_endpoint *ep,
 		struct cxlmi_tunnel_info *ti,
 		struct cxlmi_cmd_memdev_get_dc_config_req *in,

--- a/src/cxlmi/commands.c
+++ b/src/cxlmi/commands.c
@@ -2645,6 +2645,35 @@ CXLMI_EXPORT int cxlmi_cmd_fmapi_get_dc_reg_config(struct cxlmi_endpoint *ep,
 	return rc;
 }
 
+CXLMI_EXPORT int cxlmi_cmd_fmapi_set_dc_region_config(struct cxlmi_endpoint *ep,
+				    struct cxlmi_tunnel_info *ti,
+				    struct cxlmi_cmd_fmapi_set_dc_region_config *in)
+{
+	struct cxlmi_cmd_fmapi_set_dc_region_config *req_pl;
+	_cleanup_free_ struct cxlmi_cci_msg *req = NULL;
+	struct cxlmi_cci_msg rsp;
+	size_t req_sz;
+	int rc = 0;
+
+	CXLMI_BUILD_BUG_ON(sizeof(*in) != 16);
+
+	req_sz = sizeof(*req) + sizeof(*in);
+	req = calloc(1, req_sz);
+	if (!req)
+		return -1;
+
+	arm_cci_request(ep, req, sizeof(*in), DCD_MANAGEMENT, SET_DC_REGION_CONFIG);
+
+	req_pl = (struct cxlmi_cmd_fmapi_set_dc_region_config *)req->payload;
+	req_pl->region_id = in->region_id;
+	req_pl->block_sz = cpu_to_le64(in->block_sz);
+	req_pl->sanitize_on_release = in->sanitize_on_release;
+
+	rc = send_cmd_cci(ep, ti, req, req_sz, &rsp, sizeof(rsp), sizeof(rsp));
+
+	return rc;
+}
+
 CXLMI_EXPORT int cxlmi_cmd_memdev_get_dc_config(struct cxlmi_endpoint *ep,
 		struct cxlmi_tunnel_info *ti,
 		struct cxlmi_cmd_memdev_get_dc_config_req *in,

--- a/src/cxlmi/private.h
+++ b/src/cxlmi/private.h
@@ -282,6 +282,7 @@ enum {
 	#define INITIATE_DC_RELEASE         0x5
 	#define DC_ADD_REFERENCE            0x6
 	#define DC_REMOVE_REFERENCE         0x7
+	#define DC_LIST_TAGS                0x8
 };
 
 struct cxlmi_ctx {

--- a/src/cxlmi/private.h
+++ b/src/cxlmi/private.h
@@ -280,6 +280,7 @@ enum {
 	#define GET_DC_REGION_EXTENT_LIST   0x3
 	#define INITIATE_DC_ADD             0x4
 	#define INITIATE_DC_RELEASE         0x5
+	#define DC_ADD_REFERENCE            0x6
 };
 
 struct cxlmi_ctx {

--- a/src/cxlmi/private.h
+++ b/src/cxlmi/private.h
@@ -281,6 +281,7 @@ enum {
 	#define INITIATE_DC_ADD             0x4
 	#define INITIATE_DC_RELEASE         0x5
 	#define DC_ADD_REFERENCE            0x6
+	#define DC_REMOVE_REFERENCE         0x7
 };
 
 struct cxlmi_ctx {

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -652,6 +652,9 @@ int cxlmi_cmd_fmapi_get_dc_region_ext_list(struct cxlmi_endpoint *ep,
 int cxlmi_cmd_fmapi_initiate_dc_add(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_initiate_dc_add_req *in);
+int cxlmi_cmd_fmapi_initiate_dc_release(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_initiate_dc_release_req *in);
 
 
 /*

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -645,6 +645,10 @@ int cxlmi_cmd_fmapi_get_dc_reg_config(struct cxlmi_endpoint *ep,
 int cxlmi_cmd_fmapi_set_dc_region_config(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_set_dc_region_config *in);
+int cxlmi_cmd_fmapi_get_dc_region_ext_list(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_get_dc_region_ext_list_req *in,
+			struct cxlmi_cmd_fmapi_get_dc_region_ext_list_rsp *ret);
 
 
 /*

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -661,6 +661,10 @@ int cxlmi_cmd_fmapi_dc_add_reference(struct cxlmi_endpoint *ep,
 int cxlmi_cmd_fmapi_dc_remove_reference(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_dc_remove_ref *in);
+int cxlmi_cmd_fmapi_dc_list_tags(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_dc_list_tags_req *in,
+			struct cxlmi_cmd_fmapi_dc_list_tags_rsp *ret);
 
 
 /*

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -655,6 +655,9 @@ int cxlmi_cmd_fmapi_initiate_dc_add(struct cxlmi_endpoint *ep,
 int cxlmi_cmd_fmapi_initiate_dc_release(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_initiate_dc_release_req *in);
+int cxlmi_cmd_fmapi_dc_add_reference(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_dc_add_ref *in);
 
 
 /*

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -642,6 +642,9 @@ int cxlmi_cmd_fmapi_get_dc_reg_config(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_get_host_dc_region_config_req *in,
 			struct cxlmi_cmd_fmapi_get_host_dc_region_config_rsp *ret);
+int cxlmi_cmd_fmapi_set_dc_region_config(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_set_dc_region_config *in);
 
 
 /*

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -658,6 +658,9 @@ int cxlmi_cmd_fmapi_initiate_dc_release(struct cxlmi_endpoint *ep,
 int cxlmi_cmd_fmapi_dc_add_reference(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_dc_add_ref *in);
+int cxlmi_cmd_fmapi_dc_remove_reference(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_dc_remove_ref *in);
 
 
 /*

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -638,6 +638,10 @@ int cxlmi_cmd_fmapi_set_qos_bw_limit(struct cxlmi_endpoint *ep,
 int cxlmi_cmd_fmapi_get_dcd_info(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_get_dcd_info *ret);
+int cxlmi_cmd_fmapi_get_dc_reg_config(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_get_host_dc_region_config_req *in,
+			struct cxlmi_cmd_fmapi_get_host_dc_region_config_rsp *ret);
 
 
 /*

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -635,6 +635,10 @@ int cxlmi_cmd_fmapi_set_qos_bw_limit(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_set_qos_bw_limit *in,
 			struct cxlmi_cmd_fmapi_set_qos_bw_limit *ret);
+int cxlmi_cmd_fmapi_get_dcd_info(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_get_dcd_info *ret);
+
 
 /*
  * Vendor specific commands.

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -649,6 +649,9 @@ int cxlmi_cmd_fmapi_get_dc_region_ext_list(struct cxlmi_endpoint *ep,
 			struct cxlmi_tunnel_info *ti,
 			struct cxlmi_cmd_fmapi_get_dc_region_ext_list_req *in,
 			struct cxlmi_cmd_fmapi_get_dc_region_ext_list_rsp *ret);
+int cxlmi_cmd_fmapi_initiate_dc_add(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_initiate_dc_add_req *in);
 
 
 /*


### PR DESCRIPTION
This patchset adds support for 9 FM API DCD Management commands (0x5600-0x5608)
and some basic test code for each command.

Below is the output of the test code generated using cxl-test-tool and
the code implemented in my fork of QEMU
(https://github.com/anisa-su993/qemu-anisa/tree/libcxlmi-testing).

Note that 0x5604 Initiate DC Add and 0x5605 Initiate DC Release have
been hacked on the QEMU-side to ignore the concept of the "pending extent list"
for testing purposes because we are using kernel hack to enable MCTP, which
uses an older version than the kernel version with DCD support. Thus, for
testing purposes, extents are directly added/released instead of creating a
record in the event log and triggering an interrupt to the host.

For commands 0x5606 DC Add Reference and 0x5607 DC Remove Reference,
because sharing is not yet enabled in QEMU, this command always
succeeds.

0x5600: FMAPI Get DCD Info Response:
        # hosts supported: 0
        # dc regions available/host: 2
        capacity_selection_policies: 2
        capacity_removal_policies: 1
        sanitize_on_release: 0
        total dynamic capacity: 536870912
        region 0: block_size 2097152
        region 1: block_size 2097152

0x5601: FMAPI Get DC Region Config Response:
        host id: 0
        num available regions: 2
        num regions returned: 2
        num_extents_supported: 512
        num_extents_available: 512
        num_tags_supported: 0

0x5602: FMAPI Set DC Region Config
FMAPI Set DC Region Config Success
* This command does not return any output payload. We can tell it succeeded
from later commands because the both regions start with a block size of
2097152, then in testing 0x5605, we are able to add/remove extents in multiples
of 128 because the block size is set to 128 here.

0x5603: FMAPI Get DC Region Extent List
        Host Id: 0
        Starting Extent Index: 0
        Number of Extents Returned: 0
        Total Extents: 0
        Extent List Generation Number: 0

0x5604: FMAPI Initiate DC Add
FMAPI Initiate DC Add Success
Show Extents --
        Host Id: 0
        Starting Extent Index: 0
        Number of Extents Returned: 1
        Total Extents: 1
        Extent List Generation Number: 0
                Extent 0 Info:
                        Start DPA: 0
                        Length: 128

This command does not return a response payload, but printing the extent list
shows that 1 extent has been successfully added with the specified
start DPA and length. This will be used in the following "initiate dc release"
test.

0x5605: FMAPI Initiate DC Release
First tests some error conditions, such as trying to release an extent
that is not block backed (errcode 15 INVALID_PA), trying to release a misaligned
extent (errcode 30 INVALID_EXTENT_LIST), and trying to release 2 overlapping
extents (errcode 30 INVALID_EXTENT_LIST).

libcxlmi: Error code in response: 15
libcxlmi: Error code in response: 30
libcxlmi: Error code in response: 30

Printing the extents after the above 3 requests fail, there should only be 1
extent, the same one as previously added from testing the previous command.
Show Extents --
        Host Id: 0
        Starting Extent Index: 0
        Number of Extents Returned: 1
        Total Extents: 1
        Extent List Generation Number: 0
                Extent 0 Info:
                        Start DPA: 0
                        Length: 128

Next, release the previously added extent with Start DPA: 268435456 and
Length: 2097152. Printing the result, there should be no extents.
Show Extents --
        Host Id: 0
        Starting Extent Index: 0
        Number of Extents Returned: 0
        Total Extents: 0
        Extent List Generation Number: 0

Then, add one extent (3 blocks long) and release the middle block
Ext_0 = {[0 - 127] [128 - 255] [256 - 384]}. The result of adding the extent:
Show Extents --
        Host Id: 0
        Starting Extent Index: 0
        Number of Extents Returned: 1
        Total Extents: 1
        Extent List Generation Number: 0
                Extent 0 Info:
                        Start DPA: 0
                        Length: 384

After releasing the middle block, the region should have 2 extents.
Ext_0 = {[0 - 127]}
Ext_1 = {[256 - 384]}
The output printed is as expected:
Show Extents --
        Host Id: 0
        Starting Extent Index: 0
        Number of Extents Returned: 2
        Total Extents: 2
        Extent List Generation Number: 0
                Extent 0 Info:
                        Start DPA: 0
                        Length: 128
                Extent 1 Info:
                        Start DPA: 256
                        Length: 128


0x5606: FMAPI DC Add Reference
FMAPI DC Add Reference Success
* This command has no output payload. On the QEMU-side, always returns
success, since sharing is not yet enabled.

0x5607: FMAPI DC Remove Reference
FMAPI DC Remove Reference Success
* Same as 0x5606

0x5608: FMAPI DC List Tags
         Generation Num: 0
         Max Tags: 2
         Num Tags Returned: 0
* On the QEMU-side, always returns 0 tags, since sharing is not yet
enabled.