### PR TITLE
examples/cxl-mctp: fix FMAPI get DC ext list test for multiple retrieval

### DIFF
--- a/examples/examples.h
+++ b/examples/examples.h
@@ -8,6 +8,7 @@
 #include <libcxlmi.h>
 
 #define MiB (1024 * 1024)
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 
 const uint8_t cel_uuid[0x10] = { 0x0d, 0xa9, 0xc0, 0xb5,
     0xbf, 0x41,


### PR DESCRIPTION
Fix for [GitHub Issue #18](https://github.com/computexpresslink/libcxlmi/issues/18): it is possible to return less than the number of extents requested if number of extents requested is too large.

Then we need to send the command multiple times until the number of extents returned is equal to MIN(extents_requested, total_num_extents).