### PR TITLE
Minor fixes for issues detected by coverity

### DIFF
--- a/examples/cxl-mctp.c
+++ b/examples/cxl-mctp.c
@@ -892,7 +892,9 @@ static int test_fmapi_dc_add_reference(struct cxlmi_endpoint *ep)
 
 static int test_fmapi_dc_remove_reference(struct cxlmi_endpoint *ep)
 {
-	struct cxlmi_cmd_fmapi_dc_remove_ref req;
+	struct cxlmi_cmd_fmapi_dc_remove_ref req = {
+		.tag = {0}
+	};
 
 	printf("0x5607: FMAPI DC Remove Reference\n");
 	if (cxlmi_cmd_fmapi_dc_remove_reference(ep, NULL, &req)) {

--- a/examples/cxl-mctp.c
+++ b/examples/cxl-mctp.c
@@ -662,6 +662,7 @@ static int get_num_dc_extents(struct cxlmi_endpoint *ep)
 		.start_ext_index = 0
 	};
 	struct cxlmi_cmd_fmapi_get_dc_region_ext_list_rsp *rsp;
+	int rc;
 
 	rsp = calloc(1, sizeof(*rsp));
 	if (!rsp) {
@@ -669,10 +670,15 @@ static int get_num_dc_extents(struct cxlmi_endpoint *ep)
 	}
 
 	if (cxlmi_cmd_fmapi_get_dc_region_ext_list(ep, NULL, &req, rsp)) {
-		return -1;
+		rc = -1;
+		goto free_out;
 	}
 
-	return rsp->total_extents;
+	rc = rsp->total_extents;
+
+free_out:
+	free(rsp);
+	return rc;
 }
 
 static int test_fmapi_initiate_dc_add_and_release(struct cxlmi_endpoint *ep)

--- a/examples/cxl-mctp.c
+++ b/examples/cxl-mctp.c
@@ -876,7 +876,9 @@ cleanup:
 
 static int test_fmapi_dc_add_reference(struct cxlmi_endpoint *ep)
 {
-	struct cxlmi_cmd_fmapi_dc_add_ref req;
+	struct cxlmi_cmd_fmapi_dc_add_ref req = {
+		.tag = {0}
+	};
 
 	printf("0x5606: FMAPI DC Add Reference\n");
 	if (cxlmi_cmd_fmapi_dc_add_reference(ep, NULL, &req)) {

--- a/examples/cxl-mctp.c
+++ b/examples/cxl-mctp.c
@@ -561,9 +561,11 @@ static int test_fmapi_get_host_dc_region_config(struct cxlmi_endpoint *ep)
 
 	for (i = 0; i < dc_region_config_rsp->regions_returned; i++) {
 		printf("\t\tRegion %d:\n", i);
-		printf("\t\t\tBase: %lu\n", dc_region_config_rsp->region_configs->base);
-		printf("\t\t\tBlk_sz: %lu\n", dc_region_config_rsp->region_configs->block_size);
-		printf("\t\t\tLen: %lu\n", dc_region_config_rsp->region_configs->region_len);
+		printf("\t\t\tBase: %lu\n", dc_region_config_rsp->region_configs[i].base);
+		printf("\t\t\tBlk_sz: %lu\n", dc_region_config_rsp->region_configs[i].block_size);
+		printf("\t\t\tLen: %lu\n", dc_region_config_rsp->region_configs[i].region_len);
+		printf("\t\t\tDecode_len: %lu\n", dc_region_config_rsp->region_configs[i].decode_len);
+		printf("\t\t\tFlags: %hhu\n", dc_region_config_rsp->region_configs[i].flags);
 	}
 
 free_out:

--- a/examples/fmapi-mctp.c
+++ b/examples/fmapi-mctp.c
@@ -290,6 +290,7 @@ static int split_cmd_to_argv(char* cmd, char*** argvp)
             for (i = 0; i < argc; i++) {
                 free(argv[argc]);
             }
+            free(cmd_cpy);
             free(argv);
             return -1;
         }


### PR DESCRIPTION
Has fixes for FMAPI examples. Touches 2 files:

1. examples/fmapi-mctp:
    - Fix for issue #[462582](https://scan4.scan.coverity.com/#/project-view/66462/17991?selectedIssue=462582):
    Plugged leak in helper function that splits dax device commands (ex: "daxctl
    create-device...") into an argv for execv. Leak would occur if the
    argv is unable to allocate space.
    
    - Ignored issue #[462570](https://scan4.scan.coverity.com/#/project-view/66462/17991?selectedIssue=462570):
    Coverity complains in parse_extents that returning i - 1 could cause
    integer underflow, but i is initialized to 1 and monotonically
    increases.

2. examples/cxl-mctp:
   - Issue #[462580](https://scan4.scan.coverity.com/#/project-view/66462/17991?selectedIssue=462580): fixes memory leak in get_num_dc_extents
   - Issue #[462576](https://scan4.scan.coverity.com/#/project-view/66462/17991?selectedIssue=462576)/#[462563](https://scan4.scan.coverity.com/#/project-view/66462/17991?selectedIssue=462563): fmapi_dc_add/release_reference did not explicitly
      initialize the request fields because QEMU doesn't support tags. Now both explicitly
      initialize req.tag to 0.
   - Bug in test_fmapi_get_host_dc_region_config
     Not a coverity issue, but found a but in test_fmapi_get_host_dc_region_config.
     which incorrectly accesses the region_configs array