### PR TITLE
Update 0x0004: Set Response Msg Limit

### DIFF
--- a/docs/Generic-Component-Commands.md
+++ b/docs/Generic-Component-Commands.md
@@ -104,13 +104,21 @@ struct cxlmi_cmd_set_response_msg_limit {
 	uint8_t limit;
 };
    ```
+Return payload:
+
+   ```C
+struct cxlmi_cmd_set_response_msg_limit {
+	uint8_t limit;
+};
+   ```
 
 Command name:
 
    ```C
 int cxlmi_cmd_set_response_msg_limit(struct cxlmi_endpoint *ep,
 					 struct cxlmi_tunnel_info *ti,
-					 struct cxlmi_cmd_set_response_msg_limit *in);
+					 struct cxlmi_cmd_set_response_msg_limit *in,
+					 struct cxlmi_cmd_set_response_msg_limit *ret);
    ```
 
 ## Request Abort Background Operation (0005h)

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -399,7 +399,8 @@ int cxlmi_cmd_get_response_msg_limit(struct cxlmi_endpoint *ep,
 			     struct cxlmi_cmd_get_response_msg_limit *ret);
 int cxlmi_cmd_set_response_msg_limit(struct cxlmi_endpoint *ep,
 			     struct cxlmi_tunnel_info *ti,
-			     struct cxlmi_cmd_set_response_msg_limit *in);
+			     struct cxlmi_cmd_set_response_msg_limit *in,
+			     struct cxlmi_cmd_set_response_msg_limit *ret);
 int cxlmi_cmd_request_bg_op_abort(struct cxlmi_endpoint *ep,
 				  struct cxlmi_tunnel_info *ti);
 


### PR DESCRIPTION
This command has been updated in CXL r3.2 Spec Section 8.2.10.1.4 to also return the configured message limit.

Currently, if this command is sent to a QEMU-emulated device, we get the following error from sanity_check_mctp_rsp: "Payload length not matching expected part of full message 0 1" because returns QEMU returns 1 byte when libcxlmi expects 0.