### PR TITLE
Feature Commands: 0x0500 - 0x0502

### DIFF
--- a/docs/Generic-Component-Commands.md
+++ b/docs/Generic-Component-Commands.md
@@ -29,6 +29,8 @@ command set, as per the latest specification.
    * [Clear Log (0403h)](#clear-log-0403h)
    * [Populate Log (0404h)](#populate-log-0404h)
    * [Get Supported Logs Sub-List (0405h)](#get-supported-logs-sub-list-0405h)
+* [Features (05h)](#features-05h)
+	* [Get Supported Features (0500h)](#get-supported-features-0500h)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 <!-- Added by: dave, at: Tue May 21 04:42:32 PM PDT 2024 -->
@@ -579,4 +581,48 @@ int cxlmi_cmd_get_supported_logs_sublist(struct cxlmi_endpoint *ep,
 			  struct cxlmi_tunnel_info *ti,
 			  struct cxlmi_cmd_get_supported_logs_sublist_req *in,
 			  struct cxlmi_cmd_get_supported_logs_sublist_rsp *ret);
+   ```
+
+# Features (05h)
+
+## Get Supported Features (0500h)
+
+Input payload:
+
+   ```C
+struct cxlmi_cmd_get_supported_features_req {
+	uint32_t count;
+	uint16_t starting_feature_index;
+	uint8_t rsvd[2];
+};
+   ```
+
+Return payload:
+
+   ```C
+struct cxlmi_cmd_get_supported_features_rsp {
+	uint32_t num_supported_feature_entries;
+	uint16_t device_supported_features;
+	uint8_t rsvd[4];
+	struct {
+		uint8_t feature_id[0x10];
+		uint16_t feature_index;
+		uint16_t get_feature_size;
+		uint16_t set_feature_size;
+		uint32_t attribute_flags;
+		uint8_t get_feature_version;
+		uint8_t set_feature_version;
+		uint16_t set_feature_effects;
+		uint8_t rsvd[18];
+	} supported_feature_entries[];
+};
+   ```
+
+Command name:
+
+   ```C
+int cxlmi_cmd_get_supported_features(struct cxlmi_endpoint *ep,
+	struct cxlmi_tunnel_info *ti,
+	struct cxlmi_cmd_get_supported_features_req *in,
+	struct cxlmi_cmd_get_supported_features_rsp *ret);
    ```

--- a/docs/Generic-Component-Commands.md
+++ b/docs/Generic-Component-Commands.md
@@ -31,6 +31,7 @@ command set, as per the latest specification.
    * [Get Supported Logs Sub-List (0405h)](#get-supported-logs-sub-list-0405h)
 * [Features (05h)](#features-05h)
 	* [Get Supported Features (0500h)](#get-supported-features-0500h)
+	* [Get Feature (0501h)](#get-feature-0501h)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 <!-- Added by: dave, at: Tue May 21 04:42:32 PM PDT 2024 -->
@@ -625,4 +626,35 @@ int cxlmi_cmd_get_supported_features(struct cxlmi_endpoint *ep,
 	struct cxlmi_tunnel_info *ti,
 	struct cxlmi_cmd_get_supported_features_req *in,
 	struct cxlmi_cmd_get_supported_features_rsp *ret);
+   ```
+
+## Get Feature (0501h)
+
+Input payload:
+
+   ```C
+struct cxlmi_cmd_get_feature_req {
+	uint8_t feature_id[0x10];
+	uint16_t offset;
+	uint16_t count;
+	uint8_t selection;
+};
+   ```
+
+Return payload:
+
+   ```C
+#define MAX_FEATURE_SIZE 2048
+struct cxlmi_cmd_get_feature_rsp {
+	uint8_t feature_data[MAX_FEATURE_SIZE];
+};
+   ```
+
+Command name:
+
+   ```C
+int cxlmi_cmd_get_feature(struct cxlmi_endpoint *ep,
+	struct cxlmi_tunnel_info *ti,
+	struct cxlmi_cmd_get_feature_req *in,
+	struct cxlmi_cmd_get_feature_rsp *ret);
    ```

--- a/docs/Generic-Component-Commands.md
+++ b/docs/Generic-Component-Commands.md
@@ -32,6 +32,7 @@ command set, as per the latest specification.
 * [Features (05h)](#features-05h)
 	* [Get Supported Features (0500h)](#get-supported-features-0500h)
 	* [Get Feature (0501h)](#get-feature-0501h)
+	* [Set Feature (0502h)](#set-feature-0502h)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 <!-- Added by: dave, at: Tue May 21 04:42:32 PM PDT 2024 -->
@@ -657,4 +658,28 @@ int cxlmi_cmd_get_feature(struct cxlmi_endpoint *ep,
 	struct cxlmi_tunnel_info *ti,
 	struct cxlmi_cmd_get_feature_req *in,
 	struct cxlmi_cmd_get_feature_rsp *ret);
+   ```
+
+## Set Feature (0502h)
+
+Input payload:
+
+   ```C
+struct cxlmi_cmd_set_feature {
+	uint8_t feature_id[0x10];
+	uint32_t set_feature_flags;
+	uint16_t offset;
+	uint8_t version;
+	uint8_t rsvd[9];
+	uint8_t feature_data[MAX_FEATURE_SIZE];
+};
+   ```
+
+Command name:
+
+   ```C
+int cxlmi_cmd_set_feature(struct cxlmi_endpoint *ep,
+	struct cxlmi_tunnel_info *ti,
+	struct cxlmi_cmd_set_feature *in,
+	size_t feature_data_sz);
    ```

--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -233,6 +233,30 @@ struct cxlmi_cmd_get_supported_logs_sublist_rsp {
 	struct cxlmi_supported_log_entry entries[];
 } __attribute__((packed));
 
+/* CXL r3.2 Section 8.2.10.6.1 Get Supported Features (Opcode 0500h) */
+struct cxlmi_cmd_get_supported_features_req {
+	uint32_t count;
+	uint16_t starting_feature_index;
+	uint8_t rsvd[2];
+} __attribute__((packed));
+
+struct cxlmi_cmd_get_supported_features_rsp {
+	uint16_t num_supported_feature_entries;
+	uint16_t device_supported_features;
+	uint8_t rsvd[4];
+	struct {
+		uint8_t feature_id[0x10];
+		uint16_t feature_index;
+		uint16_t get_feature_size;
+		uint16_t set_feature_size;
+		uint32_t attribute_flags;
+		uint8_t get_feature_version;
+		uint8_t set_feature_version;
+		uint16_t set_feature_effects;
+		uint8_t rsvd[18];
+	} __attribute__((packed)) supported_feature_entries[];
+} __attribute__((packed));
+
 /* CXL r3.1 Section 8.2.9.9.1.1: Identify Memory Device (Opcode 4000h) */
 struct cxlmi_cmd_memdev_identify {
 	char fw_revision[0x10];

--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -270,6 +270,16 @@ struct cxlmi_cmd_get_feature_rsp {
 	uint8_t feature_data[MAX_FEATURE_SIZE];
 } __attribute__((packed));
 
+/* CXL r3.2 Section 8.2.10.6.3 Set Feature (Opcode 0502h) */
+struct cxlmi_cmd_set_feature {
+	uint8_t feature_id[0x10];
+	uint32_t set_feature_flags;
+	uint16_t offset;
+	uint8_t version;
+	uint8_t rsvd[9];
+	uint8_t feature_data[];
+} __attribute__((packed));
+
 /* CXL r3.1 Section 8.2.9.9.1.1: Identify Memory Device (Opcode 4000h) */
 struct cxlmi_cmd_memdev_identify {
 	char fw_revision[0x10];

--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -257,6 +257,19 @@ struct cxlmi_cmd_get_supported_features_rsp {
 	} __attribute__((packed)) supported_feature_entries[];
 } __attribute__((packed));
 
+/* CXL r3.2 Section 8.2.10.6.2: Get Feature (Opcode 0501h) */
+struct cxlmi_cmd_get_feature_req {
+	uint8_t feature_id[0x10];
+	uint16_t offset;
+	uint16_t count;
+	uint8_t selection;
+} __attribute__((packed));
+
+#define MAX_FEATURE_SIZE 2048
+struct cxlmi_cmd_get_feature_rsp {
+	uint8_t feature_data[MAX_FEATURE_SIZE];
+} __attribute__((packed));
+
 /* CXL r3.1 Section 8.2.9.9.1.1: Identify Memory Device (Opcode 4000h) */
 struct cxlmi_cmd_memdev_identify {
 	char fw_revision[0x10];

--- a/src/cxlmi/commands.c
+++ b/src/cxlmi/commands.c
@@ -923,6 +923,37 @@ CXLMI_EXPORT int cxlmi_cmd_get_feature(struct cxlmi_endpoint *ep,
 	return rc;
 }
 
+CXLMI_EXPORT int cxlmi_cmd_set_feature(struct cxlmi_endpoint *ep,
+	struct cxlmi_tunnel_info *ti,
+	struct cxlmi_cmd_set_feature *in,
+	size_t feature_data_sz)
+{
+	struct cxlmi_cmd_set_feature *req_pl;
+	_cleanup_free_ struct cxlmi_cci_msg *req = NULL;
+	_cleanup_free_ struct cxlmi_cci_msg *rsp = NULL;
+	ssize_t req_sz, rsp_sz;
+
+	req_sz = sizeof(*req) + sizeof(*req_pl) + feature_data_sz;
+	req = calloc(1, req_sz);
+	if (!req)
+		return -1;
+	req_pl = (struct cxlmi_cmd_set_feature *)req->payload;
+	memcpy(req_pl->feature_id, in->feature_id, 0x10);
+
+	req_pl->set_feature_flags = cpu_to_le32(in->set_feature_flags);
+	req_pl->offset = cpu_to_le16(in->offset);
+	req_pl->version = in->version;
+	memcpy(req_pl->feature_data, in->feature_data, feature_data_sz);
+	arm_cci_request(ep, req, req_sz, FEATURES, SET_FEATURE);
+
+	rsp_sz = sizeof(*rsp);
+	rsp = calloc(1, rsp_sz);
+	if (!rsp)
+		return -1;
+
+	return send_cmd_cci(ep, ti, req, req_sz, rsp, rsp_sz, rsp_sz);
+}
+
 CXLMI_EXPORT int cxlmi_cmd_memdev_identify(struct cxlmi_endpoint *ep,
 				   struct cxlmi_tunnel_info *ti,
 				   struct cxlmi_cmd_memdev_identify *ret)

--- a/src/cxlmi/commands.c
+++ b/src/cxlmi/commands.c
@@ -882,6 +882,47 @@ CXLMI_EXPORT int cxlmi_cmd_get_supported_features(struct cxlmi_endpoint *ep,
 	return rc;
 }
 
+CXLMI_EXPORT int cxlmi_cmd_get_feature(struct cxlmi_endpoint *ep,
+	struct cxlmi_tunnel_info *ti,
+	struct cxlmi_cmd_get_feature_req *in,
+	struct cxlmi_cmd_get_feature_rsp *ret)
+{
+	struct cxlmi_cmd_get_feature_req *req_pl;
+	struct cxlmi_cmd_get_feature_rsp *rsp_pl;
+	_cleanup_free_ struct cxlmi_cci_msg *req = NULL;
+	_cleanup_free_ struct cxlmi_cci_msg *rsp = NULL;
+	ssize_t req_sz, rsp_sz_min, rsp_sz;
+	int rc = -1;
+
+	CXLMI_BUILD_BUG_ON(sizeof(*in) != 21);
+
+	req_sz = sizeof(*req) + sizeof(*req_pl);
+	req = calloc(1, req_sz);
+	if (!req)
+		return -1;
+	req_pl = (struct cxlmi_cmd_get_feature_req *)req->payload;
+	memcpy(req_pl->feature_id, in->feature_id, 0x10);
+	req_pl->offset = cpu_to_le16(in->offset);
+	req_pl->count = cpu_to_le16(in->count);
+	req_pl->selection = in->selection;
+	arm_cci_request(ep, req, req_sz, FEATURES, GET_FEATURE);
+
+	rsp_sz_min = sizeof(*rsp) + in->count;
+	rsp_sz = sizeof(*rsp) + sizeof(*rsp_pl);
+	rsp = calloc(1, rsp_sz);
+	if (!rsp)
+		return -1;
+
+	rc = send_cmd_cci(ep, ti, req, req_sz, rsp, rsp_sz, rsp_sz_min);
+	if (rc)
+		return rc;
+
+	rsp_pl = (struct cxlmi_cmd_get_feature_rsp *)rsp->payload;
+	memcpy(rsp_pl->feature_data, ret->feature_data, in->count);
+
+	return rc;
+}
+
 CXLMI_EXPORT int cxlmi_cmd_memdev_identify(struct cxlmi_endpoint *ep,
 				   struct cxlmi_tunnel_info *ti,
 				   struct cxlmi_cmd_memdev_identify *ret)

--- a/src/cxlmi/private.h
+++ b/src/cxlmi/private.h
@@ -211,6 +211,7 @@ enum {
 	FEATURES	= 0x05,
 	#define GET_SUPPORTED_FEATURES 0x0
 	#define GET_FEATURE 0x1
+	#define SET_FEATURE 0x2
     IDENTIFY    = 0x40,
 	#define MEMORY_DEVICE 0x0
     CCLS        = 0x41,

--- a/src/cxlmi/private.h
+++ b/src/cxlmi/private.h
@@ -210,6 +210,7 @@ enum {
 	#define GET_SUPPORTED_SUBLIST  0x5
 	FEATURES	= 0x05,
 	#define GET_SUPPORTED_FEATURES 0x0
+	#define GET_FEATURE 0x1
     IDENTIFY    = 0x40,
 	#define MEMORY_DEVICE 0x0
     CCLS        = 0x41,

--- a/src/cxlmi/private.h
+++ b/src/cxlmi/private.h
@@ -208,6 +208,8 @@ enum {
 	#define CLEAR_LOG     0x3
 	#define POPULATE_LOG  0x4
 	#define GET_SUPPORTED_SUBLIST  0x5
+	FEATURES	= 0x05,
+	#define GET_SUPPORTED_FEATURES 0x0
     IDENTIFY    = 0x40,
 	#define MEMORY_DEVICE 0x0
     CCLS        = 0x41,

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -479,6 +479,10 @@ int cxlmi_cmd_get_feature(struct cxlmi_endpoint *ep,
 	struct cxlmi_tunnel_info *ti,
 	struct cxlmi_cmd_get_feature_req *in,
 	struct cxlmi_cmd_get_feature_rsp *ret);
+int cxlmi_cmd_set_feature(struct cxlmi_endpoint *ep,
+	struct cxlmi_tunnel_info *ti,
+	struct cxlmi_cmd_set_feature *in,
+	size_t feature_data_sz);
 
 /*
  * Definitions for Memory Device Commands, per CXL r3.1 Table 8-126.

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -475,6 +475,10 @@ int cxlmi_cmd_get_supported_features(struct cxlmi_endpoint *ep,
 	struct cxlmi_tunnel_info *ti,
 	struct cxlmi_cmd_get_supported_features_req *in,
 	struct cxlmi_cmd_get_supported_features_rsp *ret);
+int cxlmi_cmd_get_feature(struct cxlmi_endpoint *ep,
+	struct cxlmi_tunnel_info *ti,
+	struct cxlmi_cmd_get_feature_req *in,
+	struct cxlmi_cmd_get_feature_rsp *ret);
 
 /*
  * Definitions for Memory Device Commands, per CXL r3.1 Table 8-126.

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -471,7 +471,10 @@ int cxlmi_cmd_get_supported_logs_sublist(struct cxlmi_endpoint *ep,
 			  struct cxlmi_tunnel_info *ti,
 			  struct cxlmi_cmd_get_supported_logs_sublist_req *in,
 			  struct cxlmi_cmd_get_supported_logs_sublist_rsp *ret);
-
+int cxlmi_cmd_get_supported_features(struct cxlmi_endpoint *ep,
+	struct cxlmi_tunnel_info *ti,
+	struct cxlmi_cmd_get_supported_features_req *in,
+	struct cxlmi_cmd_get_supported_features_rsp *ret);
 
 /*
  * Definitions for Memory Device Commands, per CXL r3.1 Table 8-126.


### PR DESCRIPTION
Adds support for the Feature Command Set (05h) as defined in CXL r3.2:
1. Section 8.2.10.6.1 - Get Supported Features (Opcode 0500h)
2. Section 8.2.10.6.2 - Get Feature (Opcode 0501h)
3. Section 8.2.10.6.3 - Set Feature (Opcode 0502h)

These were tested using the following topology (1 direct attached T3 device w/o MCTP) with cxl-test-tool and QEMU:

`"-object memory-backend-file,id=cxl-mem1,share=on,mem-path=/tmp/cxltest.raw,size=512M \
     -object memory-backend-file,id=cxl-lsa1,share=on,mem-path=/tmp/lsa.raw,size=1M \
     -device pxb-cxl,bus_nr=12,bus=pcie.0,id=cxl.1,hdm_for_passthrough=true \
     -device cxl-rp,port=0,bus=cxl.1,id=root_port13,chassis=0,slot=2 \
     -device cxl-type3,bus=root_port13,memdev=cxl-mem1,lsa=cxl-lsa1,id=cxl-pmem0,sn=0xabcd \
     -M cxl-fmw.0.targets.0=cxl.1,cxl-fmw.0.size=4G,cxl-fmw.0.interleave-granularity=8k"
`

The test program used can be found [here](https://github.com/anisa-su993/libcxlmi/commit/ae185573caf8b3fd3399db158562bb7bd6c9e797) (made branch for it because the VPN blocks me from attaching the test program as a file here, not for upstream, there are definitely memleaks)