### PR TITLE
Feature Commands (0500h-0502h)

### DIFF
--- a/docs/Generic-Component-Commands.md
+++ b/docs/Generic-Component-Commands.md
@@ -32,6 +32,7 @@ command set, as per the latest specification.
 * [Features (05h)](#features-05h)
 	* [Get Supported Features (0500h)](#get-supported-features-0500h)
 	* [Get Feature (0501h)](#get-feature-0501h)
+	* [Set Feature (0502h)](#set-feature-0502h)
 
 <!-- Created by https://github.com/ekalinin/github-markdown-toc -->
 <!-- Added by: dave, at: Tue May 21 04:42:32 PM PDT 2024 -->
@@ -656,4 +657,28 @@ int cxlmi_cmd_get_feature(struct cxlmi_endpoint *ep,
 	struct cxlmi_tunnel_info *ti,
 	struct cxlmi_cmd_get_feature_req *in,
 	struct cxlmi_cmd_get_feature_rsp *ret);
+   ```
+
+## Set Feature (0502h)
+
+Input payload:
+
+   ```C
+struct cxlmi_cmd_set_feature {
+	uint8_t feature_id[0x10];
+	uint32_t set_feature_flags;
+	uint16_t offset;
+	uint8_t version;
+	uint8_t rsvd[9];
+	uint8_t feature_data[MAX_FEATURE_SIZE];
+};
+   ```
+
+Command name:
+
+   ```C
+int cxlmi_cmd_set_feature(struct cxlmi_endpoint *ep,
+	struct cxlmi_tunnel_info *ti,
+	struct cxlmi_cmd_set_feature *in,
+	size_t feature_data_sz);
    ```

--- a/src/cxlmi/api-types.h
+++ b/src/cxlmi/api-types.h
@@ -271,6 +271,16 @@ struct cxlmi_cmd_get_feature_rsp {
 	uint8_t feature_data[CXL_MAILBOX_MAX_PAYLOAD_SIZE];
 } __attribute__((packed));
 
+/* CXL r3.2 Section 8.2.10.6.3 Set Feature (Opcode 0502h) */
+struct cxlmi_cmd_set_feature {
+	uint8_t feature_id[0x10];
+	uint32_t set_feature_flags;
+	uint16_t offset;
+	uint8_t version;
+	uint8_t rsvd[9];
+	uint8_t feature_data[];
+} __attribute__((packed));
+
 /* CXL r3.1 Section 8.2.9.9.1.1: Identify Memory Device (Opcode 4000h) */
 struct cxlmi_cmd_memdev_identify {
 	char fw_revision[0x10];

--- a/src/cxlmi/private.h
+++ b/src/cxlmi/private.h
@@ -211,6 +211,7 @@ enum {
 	FEATURES	= 0x05,
 	#define GET_SUPPORTED_FEATURES 0x0
 	#define GET_FEATURE 0x1
+	#define SET_FEATURE 0x2
     IDENTIFY    = 0x40,
 	#define MEMORY_DEVICE 0x0
     CCLS        = 0x41,

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -479,6 +479,10 @@ int cxlmi_cmd_get_feature(struct cxlmi_endpoint *ep,
 	struct cxlmi_tunnel_info *ti,
 	struct cxlmi_cmd_get_feature_req *in,
 	struct cxlmi_cmd_get_feature_rsp *ret);
+int cxlmi_cmd_set_feature(struct cxlmi_endpoint *ep,
+	struct cxlmi_tunnel_info *ti,
+	struct cxlmi_cmd_set_feature *in,
+	size_t feature_data_sz);
 
 /*
  * Definitions for Memory Device Commands, per CXL r3.1 Table 8-126.


### PR DESCRIPTION
This patchset implements the Feature command set per CXL r3.2:
- Get Supported Features 0500h
- Get Feature 0501h
- Set Feature 0502h

It has been tested on a QEMU VM started by cxl-test-tool with the following topology (direct attached type 3 device):
`"-object memory-backend-file,id=cxl-mem1,share=on,mem-path=/tmp/cxltest.raw,size=512M \
     -object memory-backend-file,id=cxl-lsa1,share=on,mem-path=/tmp/lsa.raw,size=1M \
     -device pxb-cxl,bus_nr=12,bus=pcie.0,id=cxl.1,hdm_for_passthrough=true \
     -device cxl-rp,port=0,bus=cxl.1,id=root_port13,chassis=0,slot=2 \
     -device cxl-type3,bus=root_port13,memdev=cxl-mem1,lsa=cxl-lsa1,id=cxl-pmem0,sn=0xabcd \
     -M cxl-fmw.0.targets.0=cxl.1,cxl-fmw.0.size=4G,cxl-fmw.0.interleave-granularity=8k"`

QEMU currently supports 2 features, ECS and Patrol Scrub. This patchset is tested using this [test program](https://github.com/computexpresslink/libcxlmi/commit/02d080a3613677333f1503c297ca91ed55f0f959) (not for upstream). To summarize the test program:

1. Opens an ioctl endpoint
2. Sends the Get Supported Features command to get 1 supported feature out of a total of 2 (ECS)
3. Sends the Get Feature command to get ECS
4. Sends the Set Feature command to set Patrol Scrub