### PR TITLE
examples/cxl-mctp.c: Add test support for Physical Port Control

### DIFF
--- a/examples/examples.h
+++ b/examples/examples.h
@@ -49,6 +49,13 @@ typedef struct {
     uint64_t len;
 } extent;
 
+typedef enum physical_port_control_opcode {
+    ASSERT_PERST = 0x00,
+    DEASSERT_PERST = 0x01,
+    RESET_PPB = 0x02,
+    MAX_PPC_OPCODE
+} physical_port_control_opcode;
+
 static int parse_supported_logs(struct cxlmi_cmd_get_supported_logs *pl,
 				size_t *cel_size)
 {


### PR DESCRIPTION
-Added test support for physical port control (Opcode 5102h) to test
 all active ports and all opcodes per active port.
-refactored Get Physical Port State (Opcode 5101h) according to active
 port bitmask.