### PR TITLE
Add support for CodeConstruct mctpd v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,8 +368,10 @@ meson setup --default-library=static build
 ```
 Also, to configure with dbus support to enable MCTP scanning:
 ```
-meson setup -Dlibdbus=enabled build
+meson setup -Dlibdbus=enabled -Dmctpd=(openbmc | codeconstruct) build
 ```
+The `mctpd` option defaults to "codeconstruct", which refers to CodeConstruct's
+[mctpd v2](https://codeconstruct.com.au/docs/mctp-utils-v2-0-release/).
 
 To configure a build for debugging purposes (i.e. optimization turned
 off and debug symbols enabled):

--- a/meson.build
+++ b/meson.build
@@ -48,6 +48,27 @@ else
 	    'tools=false',
 	],
     )
+
+    mctpd = get_option('mctpd').to_lower()
+
+    if mctpd == ''
+        mctpd = 'openbmc'
+    endif
+
+    valid = ['openbmc', 'codeconstruct']
+    if not(valid.contains(mctpd))
+        error('Invalid mctpd option: ' + mctpd)
+    endif
+
+    if mctpd == 'openbmc'
+        conf.set_quoted('MCTP_DBUS_PATH', '/xyz/openbmc_project/mctp')
+        conf.set_quoted('MCTP_DBUS_IFACE', 'xyz.openbmc_project.MCTP')
+        conf.set_quoted('MCTP_DBUS_IFACE_ENDPOINT', 'xyz.openbmc_project.MCTP.Endpoint')
+    else
+        conf.set_quoted('MCTP_DBUS_PATH', '/au/com/codeconstruct/mctp1')
+        conf.set_quoted('MCTP_DBUS_IFACE', 'au.com.codeconstruct.MCTP1')
+        conf.set_quoted('MCTP_DBUS_IFACE_ENDPOINT', 'xyz.openbmc_project.MCTP.Endpoint')
+    endif
 endif
 
 conf.set('CONFIG_DBUS', libdbus_dep.found(), description: 'Enable dbus support?')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 option('libdbus', type : 'feature', value: 'disabled', description : 'libdbus support')
+option('mctpd', type: 'string', value: '', description: 'MCTP daemon type (openbmc or codeconstruct, case-insensitive). Option only valid if libdbus enabled.')
 option('tests', type : 'boolean', value : true, description : 'build tests')

--- a/src/cxlmi/cxlmi.c
+++ b/src/cxlmi/cxlmi.c
@@ -1249,10 +1249,6 @@ err_close_ep:
 
 #ifdef CONFIG_DBUS
 
-#define MCTP_DBUS_PATH "/xyz/openbmc_project/mctp"
-#define MCTP_DBUS_IFACE "xyz.openbmc_project.MCTP"
-#define MCTP_DBUS_IFACE_ENDPOINT "xyz.openbmc_project.MCTP.Endpoint"
-
 static int cxlmi_mctp_add(struct cxlmi_ctx *ctx, unsigned int netid, __u8 eid)
 {
 	struct cxlmi_endpoint *ep = NULL;


### PR DESCRIPTION
### Overview
To enable MCTP/USB endpoints, [CodeConstruct's mctpd](https://github.com/CodeConstruct/mctp/tree/main#) is used. It was upgraded in September 2024 to `v2` which moves dbus hierarchy root to `/au/com/codeconstruct/mctp`. For cxlmi_scan_mctp() to work, the `MCTP_DBUS_PATH` and `MCTP_DBUS_IFACE` definitions need to be updated to `/au/com/codeconstruct/mctp1` and `au.com.codeconstruct.MCTP1` respectively.

This is done through adding a new option to meson_options.txt ('openbmc' or 'codeconstruct'), which allows users to specify which mctpd implementation is used. Defaults to 'openbmc'. `MCTP_DBUS_PATH` and `MCTP_DBUS_PATH` are then defined based on the argument. To use the new option:

`meson setup -Dlibdbus=enabled -Dmctpd=(openbmc | codeconstruct) build`

### Testing
To ensure that this change still works with -Dmctpd=openbmc:
- VM is started
- Clone [CodeConstruct mctp repo](https://github.com/CodeConstruct/mctp/tree/main#) and reset HEAD to a previous commit:
`git reset --hard 69ed224ff9b5206ca7f3a5e047a9da61377d2ca7`
- Set up mctpd with old implementation
- libcxlmi compiled with: `meson setup -Dlibdbus=enabled -Dmctpd=openbmc build`
- run `build/examples/cxl-mctp`, which scans d-bus when no arguments passed in
- Number of endpoints opened and output is verified

To ensure that this change works with -Dmctpd=codeconstruct:
- VM is started
- Clone [CodeConstrcut mctp repo](https://github.com/CodeConstruct/mctp/tree/main#)
- libcxlmi compiled with: `meson setup -Dlibdbus=enabled build`
- run `build/examples/cxl-mctp`, which scans d-bus when no arguments passed in
- Number of endpoints opened and output is verified

### Notes
Notice that the definition for `MCTP_DBUS_IFACE_ENDPOINT` remains the same (`xyz.openbmc_project.MCTP.Endpoint`) even if the DBUS_PATH and DBUS_IFACE are changed. This is because the array returned by GetManagedObjects is slightly different when using CodeConstruct's mctpd v2:
In `src/cxlmi.c:1456` we call GetManagedObjects:
```
msg = dbus_message_new_method_call(MCTP_DBUS_IFACE,
					   MCTP_DBUS_PATH,
					   "org.freedesktop.DBus.ObjectManager",
					   "GetManagedObjects");
```
The output of this is an array of nested dict items, and now, an MCTP endpoint object looks like this after calling `busctl call au.com.codeconstruct.MCTP1 /au/com/codeconstruct/mctp1 org.freedesktop.DBus.ObjectManager GetManagedObjects`:

"/au/com/codeconstruct/mctp1/networks/1/endpoints/8": {
    "org.freedesktop.DBus.Peer": {},
    "org.freedesktop.DBus.Introspectable": {},
    "org.freedesktop.DBus.Properties": {},
    "xyz.openbmc_project.Common.UUID": {
      "UUID": "00000000-0000-0000-0000-000000000000"
    },
    **"au.com.codeconstruct.MCTP.Endpoint1"**: {
      "Connectivity": "Available"
    },
    **"xyz.openbmc_project.MCTP.Endpoint":** {
      "NetworkId": 1,
      "EID": 8,
      "SupportedMessageTypes": [7, 8]
    }
  }

Notice there is a new dict `au.com.codeconstruct.MCTP.Endpoint1`, but the `MCTP_DBUS_IFACE_ENDPOINT` macro remains unchanged because the NetworkId, EID, and SupportedMessageTypes information is still stored under the `xyz.openbmc_project.MCTP.Endpoint` dict.

For reference, CodeConstruct's changes in mctpd v2 is documented [here](https://codeconstruct.com.au/docs/mctp-utils-v2-0-release/)