### PR TITLE
tests: Set Up QEMU-based Testing

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,0 +1,157 @@
+name: Run Tests
+
+env:
+  VM_PORT: 2025
+  PYTHONUNBUFFERED: 1
+  HOME: /root
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  qemu-tests:
+    runs-on: ubuntu-latest
+    container:
+      image: anisasu/dcd-v6-image
+      options: --user root
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      # Checkout the current repo
+      - name: Checkout current repo
+        uses: actions/checkout@v4
+
+      - name: Clone cxl-test-tool
+        run: |
+            CXL_TEST_TOOL_URL=https://github.com/anisa-su993/anisa-cxl-test-tool.git
+            CXL_TEST_TOOL_BRANCH=libcxlmi-testing
+            git clone --single-branch --branch $CXL_TEST_TOOL_BRANCH $CXL_TEST_TOOL_URL ~/cxl-test-tool
+            ln -s ~/cxl-test-tool/cxl-tool.py /usr/local/bin/cxl-tool
+
+      # Test VM Startup & SSH Connection
+      - name: Test Start VM
+        run: |
+          TOPO='-object memory-backend-file,id=cxl-mem1,share=on,mem-path=/tmp/cxltest.raw,size=512M -object memory-backend-file,id=cxl-lsa1,share=on,mem-path=/tmp/lsa.raw,size=1M -device pxb-cxl,bus_nr=12,bus=pcie.0,id=cxl.1,hdm_for_passthrough=true -device cxl-rp,port=0,bus=cxl.1,id=root_port13,chassis=0,slot=2 -device cxl-type3,bus=root_port13,memdev=cxl-mem1,lsa=cxl-lsa1,id=cxl-pmem0,sn=0xabcd -M cxl-fmw.0.targets.0=cxl.1,cxl-fmw.0.size=4G,cxl-fmw.0.interleave-granularity=8k'
+          echo "cxl-tool --run -A tcg --raw -T '$TOPO'" && cxl-tool --run -A tcg --raw -T "$TOPO"
+
+      - name: Wait for QEMU guest to boot
+        run: |
+            QEMU_LOG=~/logs/qemu0.log
+            START=login:
+            timeout=90
+            start=$(date +%s)
+
+            echo "🟡 Waiting for '$START' in $QEMU_LOG..."
+
+            while true; do
+            if grep -q "$START" "$QEMU_LOG"; then
+                echo "✅ QEMU Guest Booted!"
+                break
+            fi
+
+            now=$(date +%s)
+            if (( now - start > timeout )); then
+                echo "❌ Timed out waiting for guest to boot."
+                exit 1
+            fi
+
+            sleep 1
+            done
+
+      - name: Test VM SSH
+        run: |
+            echo "ssh-keyscan -p $VM_PORT 127.0.0.1" && ssh-keyscan -p $VM_PORT 127.0.0.1
+            echo "ssh-keyscan -p $VM_PORT 127.0.0.1  | sed 's/\[127\.0\.0\.1\]/[localhost]/' >> /root/.ssh/known_hosts"
+            ssh-keyscan -p $VM_PORT 127.0.0.1  | sed 's/\[127\.0\.0\.1\]/[localhost]/' >> /root/.ssh/known_hosts
+            echo "cat /root/.ssh/known_hosts" && cat /root/.ssh/known_hosts
+            echo 'ssh -v -p 2025 root@localhost "ls"' && ssh -v -p 2025 root@localhost "ls"
+
+      # Set up NDCTL on VM, to skip later when booting up actual test VMs
+      - name: Install NDCTL
+        run: |
+            cxl-tool --install-ndctl
+
+      - name: Test VM Shutdown
+        run: |
+            QEMU_LOG=~/logs/qemu0.log
+            SHUTDOWN='reboot: Power down'
+            timeout=60
+
+            echo "cxl-tool --cmd 'sync && poweroff'"
+            cxl-tool --cmd 'sync && poweroff'
+            start=$(date +%s)
+
+            echo "🟡 Waiting for $SHUTDOWN in $QEMU_LOG..."
+
+            while true; do
+            if grep -q "$SHUTDOWN" "$QEMU_LOG"; then
+                echo "✅ QEMU shut down successfully."
+                break
+            fi
+
+            now=$(date +%s)
+            if (( now - start > timeout )); then
+                echo "❌ Timed out waiting for guest to boot."
+                ps aux | '[q]emu-system-x86-64'  # show qemu processes
+                exit 1
+            fi
+
+            sleep 1
+            done
+
+      # Cat QEMU Logs
+      - name: cat Test VM Logs
+        run: |
+            cat ~/logs/qemu0.log
+
+      # Run All Tests
+      - name: Run Tests
+        run: |
+            python3 tests/qemu-tests/run_tests.py
+        shell: bash
+        timeout-minutes: 30
+
+      # Ensure logging directories exist
+      - name: Ensure logs directory exists
+        if: always()
+        run: |
+          mkdir -p ~/logs/
+
+      - name: cat logs
+        if: always()
+        run: |
+            find ~/logs -type f | while read -r file; do
+                echo "==> $file <=="
+                cat "$file"
+                echo
+            done
+
+      - name: cat output
+        if: always()
+        run: |
+            mkdir -p tests/qemu-tests/output
+            find tests/qemu-tests/output/ -type f | while read -r file; do
+                echo "==> $file <=="
+                cat "$file"
+                echo
+            done
+
+      # Upload logs from the VM
+      - name: Upload VM Logs
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: logs
+          path: ~/logs/
+
+      # Upload test files generated and their output
+      - name: Upload Generated Test Files & Results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-files
+          path: tests/qemu-tests/output/

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,3 +8,5 @@ executable(
     dependencies: libcxlmi_dep,
     include_directories: [inc]
 )
+
+subdir('qemu-tests')

--- a/tests/meson.build.rej
+++ b/tests/meson.build.rej
@@ -1,0 +1,7 @@
+diff a/tests/meson.build b/tests/meson.build	(rejected hunks)
+@@ -8,3 +8,5 @@ executable(
+     dependencies: libcxlmi_dep,
+     include_directories: [inc]
+ )
++
++subdir('qemu-tests')

--- a/tests/qemu-tests/README.md
+++ b/tests/qemu-tests/README.md
@@ -1,0 +1,174 @@
+# libcxlmi-testing
+This page describes how libcxlmi is tested with QEMU.
+
+## Table of Contents
+- [Overview](#overview)
+- [Usage](#usage)
+- [Goals](#goals)
+- [How To Add a Test Case](#how-to-add-a-test-case)
+
+## Overview
+This section gives an overview of how the CI is run:
+
+1. When a pull request is made, it will trigger a GitHub Runner to start and run
+the workflow defined in `.github/workflows/run-tests.yml`.
+2. A container is started using a Docker image with QEMU, Linux, and cxl-test-tool configured
+3. In the container, `run_tests.py` generates test code for different CXL
+topologies, starts VMs for the different tests, and executes tests on the VMs.
+
+All test cases are defined in XML under `tests/qemu-tests/inputs`.
+Tests are organized into files, which correspond to the suite they belong to,
+which is determined by the topology they are run on. Currently there are 2 suites,
+MAILBOX and MCTP.
+Suites are defined in `tests/qemu-tests/suites.py`
+
+### Environment Info
+All tests are run on container created from this image: [anisasu/dcd-v6-image](https://hub.docker.com/repository/docker/anisasu/dcd-v6-image/general)
+The QEMU and Linux versions compiled on the image are:
+    > QEMU Branch: https://github.com/anisa-su993/qemu-anisa/tree/upstream-07-23-2025-usb-mctp
+        > Upstream as of 07-23-2025 with Jonathan Cameron's [USB MCTP patches](https://lore.kernel.org/linux-cxl/20250609163334.922346-1-Jonathan.Cameron@huawei.com/T/#m21b9e0dfc689cb1890bb4d961710c23379e04902) applied
+    > Linux version (Ira's dcd-v6): https://github.com/anisa-su993/anisa-linux-kernel/tree/dcd-v6-2025-04-13
+        > The bzImage, kernel modules, and .config can all be found here for reference: https://github.com/anisa-su993/anisa-linux-kernel/releases/tag/usb-mctp-dcd
+
+[cxl-test-tool](https://github.com/moking/cxl-test-tool) is used to facilitate
+starting VMs with different CXL topologies. This [branch](https://github.com/moking/cxl-test-tool/compare/main...anisa-su993:anisa-cxl-test-tool:libcxlmi-testing)
+containing some tweaks needed for the CI is used.
+
+### Notes:
+- The test code generation relies on the top-level `docs/` directory to get the
+request/response struct names and method signatures for each command.
+If the docs don't match the actual library struct type/method signatures, the
+test files generated will not compile.
+
+## Usage:
+There are multiple ways to run locally:
+
+### Simulate GH Runner Locally
+To simulate the full Github Runner (recommended) using the workflow `.github/workflows/run-tests.yml`,
+you will need to install [act](https://github.com/nektos/act/releases) and Docker, a tool which simulates
+a Github Runner using Docker. This will most closely emulate the GitHub Runner's environment.
+
+`run-tests.yml` runs in a container using an image with the kernel, kernel modules, QEMU binary, and
+QEMU image, and [cxl-test-tool](https://github.com/moking/cxl-test-tool) already set up, which avoids configuration/environment issues.
+
+Run `act` with the following command:
+`act --privileged -W <path to run-tests.yml from working dir> pull_request`
+
+`run-tests.yml` will run all tests. To run a single test or suite in the same environment, modify the "Run Tests" step defined in the workflow, which calls
+the `run_test.py` script:
+
+`python3 run_tests.py [OPTIONS]`
+
+Default (no args): runs all tests in all suites
+`-t --test [opcode]`: runs test for that opcode
+`-s --suite [suite]`: runs tests in that suite (defined in `tests/qemu-tests/suites.py`)
+
+### Generate Test Files Only
+`tests/qemu-tests/generate_tests.py` is self-contained and can generate test files for each opcode. To use:
+
+`python3 generate_tests.py [optional: suite]`
+
+Default (no args): generate test-XXXX.c files for each opcode defined in the XML files in `tests/qemu-tests/inputs`
+`[suite]`: generate tests for commands for that suite (defined in `SUITES` in `topo.py`)
+
+It is up to the user to start a QEMU VM with the correct topology to execute the test file.
+
+## Goal
+The goal of end-to-end tests with QEMU is to ensure that the library is able to properly interact with the device, which includes all the layers between calling the cxlmi_cmd_X() function to interpreting and returning the end result from the device. As an example of what gets called from a cxlmi_cmd_X() call:
+
+`cxlmi_cmd_identify() → send_cmd_cci() → send_mctp_direct() → sanity_check_mctp_rsp()`
+
+This example shows the call stack for a direct MCTP message, but it will be different for an ioctl endpoint and/or with tunneling.
+
+The best way to test this sequence of interactions will be with QEMU.
+
+## How to Add a Test Case:
+Add the input/output payload you want to test in the XML file for the suite it belongs to. Some commands don't have any input/output, some have one or the other, or both:
+
+```
+# This command has both an input and output
+int cxlmi_cmd_fmapi_dc_list_tags(struct cxlmi_endpoint *ep,
+			struct cxlmi_tunnel_info *ti,
+			struct cxlmi_cmd_fmapi_dc_list_tags_req *in,
+			struct cxlmi_cmd_fmapi_dc_list_tags_rsp *ret);
+
+# This command only has an output and no input
+int cxlmi_cmd_fmapi_identify_sw_device(struct cxlmi_endpoint *ep,
+		       struct cxlmi_tunnel_info *ti,
+		       struct cxlmi_cmd_fmapi_identify_sw_device *ret);
+
+# This command only has an input and no output
+int cxlmi_cmd_memdev_release_dc(struct cxlmi_endpoint *ep,
+				struct cxlmi_tunnel_info *ti,
+				struct cxlmi_cmd_memdev_release_dc *in);
+
+# This command has no input or output
+int cxlmi_cmd_request_bg_op_abort(struct cxlmi_endpoint *ep,
+				  struct cxlmi_tunnel_info *ti);
+```
+
+Commands must be defined correctly in the input file or behavior is undefined
+(most likely the test code will not compile).
+Ex: defining an input when none is expected, including an incorrect field in
+the req/rsp
+
+Below is an example of the definition of a command with both input and output:
+```
+<command opcode="0004">
+    <request>
+        <limit>10</limit>
+    </request>
+    <response>
+        <limit>10</limit>
+    </response>
+</command>
+```
+This corresponds to the following libcxlmi command with the corresponding request/response struct(s):
+```
+int cxlmi_cmd_set_response_msg_limit(struct cxlmi_endpoint *ep,
+			     struct cxlmi_tunnel_info *ti,
+			     struct cxlmi_cmd_set_response_msg_limit *in,
+			     struct cxlmi_cmd_set_response_msg_limit *ret);
+
+/* CXL r3.1 Section 8.2.9.1.4: Set Response Message Limit (Opcode 0004h) */
+struct cxlmi_cmd_set_response_msg_limit {
+	uint8_t limit;
+} __attribute__((packed));
+```
+The above XML will generate the following code:
+
+```
+struct cxlmi_cmd_set_response_msg_limit *actual = (struct cxlmi_cmd_set_response_msg_limit *) buf;
+
+rc = cxlmi_cmd_set_response_msg_limit(ep, NULL, &request, actual);
+if (rc != 0) {
+    fprintf(stderr, "Error: Function cxlmi_cmd_set_response_msg_limit returned  non-zero rc: %d\n", rc);
+    goto cleanup;
+}
+ASSERT_EQUAL(expected, actual, limit);
+```
+Note that the output defined in the XML file is the *expected output*. Defining the expected output is *optional*. If none is defined, the generated code will only check the rc. For example:
+
+```
+<command opcode="0004">
+    <request>
+        <limit>10</limit>
+    </request>
+    <response>
+        <!-- empty -->
+    </response>
+</command>
+```
+Notice that the `<response>` node is still required. The `<response>` node *must*
+bt included for every command that expects a response. Filling out the fields is
+optional and the response node can be empty.
+This will generate the following test code, skipping the assertions:
+```
+struct cxlmi_cmd_set_response_msg_limit *actual = (struct cxlmi_cmd_set_response_msg_limit *) buf;
+
+rc = cxlmi_cmd_set_response_msg_limit(ep, NULL, &request, actual);
+if (rc != 0) {
+    fprintf(stderr, "Error: Function cxlmi_cmd_set_response_msg_limit returned  non-zero rc: %d\n", rc);
+    goto cleanup;
+}
+```

--- a/tests/qemu-tests/generate_tests.py
+++ b/tests/qemu-tests/generate_tests.py
@@ -1,0 +1,368 @@
+import sys
+import os
+import suites
+from parse_docs import generate_default_opcode_map
+import xml.etree.ElementTree as ET
+
+CURR_DIR = os.path.dirname(os.path.abspath(__file__))
+
+PREFIX = """#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <libcxlmi.h>
+
+#define MAX_PAYLOAD_SIZE 4096
+
+static inline void freep(void *p)
+{
+	free(*(void **)p);
+}
+#define _cleanup_free_ __attribute__((cleanup(freep)))
+
+#define UUID(time_low, time_mid, time_hi_and_version,                    \\
+  clock_seq_hi_and_reserved, clock_seq_low, node0, node1, node2,         \\
+  node3, node4, node5)                                                   \\
+  { ((time_low) >> 24) & 0xff, ((time_low) >> 16) & 0xff,                \\
+    ((time_low) >> 8) & 0xff, (time_low) & 0xff,                         \\
+    ((time_mid) >> 8) & 0xff, (time_mid) & 0xff,                         \\
+    ((time_hi_and_version) >> 8) & 0xff, (time_hi_and_version) & 0xff,   \\
+    (clock_seq_hi_and_reserved), (clock_seq_low),                        \\
+    (node0), (node1), (node2), (node3), (node4), (node5)                 \\
+  }
+"""
+
+ASSERT_MACRO = """
+#define ASSERT_EQUAL(expected, actual) \\
+    if (expected != actual) { \\
+        printf("Assertion failed: %s = %llu, %s = %llu\\n", \\
+               #expected, (unsigned long long)(expected), \\
+               #actual, (unsigned long long)(actual)); \\
+        rc = EXIT_FAILURE; \\
+    }
+"""
+
+REQ_BUF = "req"
+RSP_BUF = "rsp"
+EXPECTED_BUF = "expected"
+
+MAIN = f"""
+int main() {{
+    struct cxlmi_ctx *ctx;
+    struct cxlmi_endpoint *ep;
+    _cleanup_free_ void *{REQ_BUF} = calloc(1, MAX_PAYLOAD_SIZE);
+    _cleanup_free_ void *{RSP_BUF} = calloc(1, MAX_PAYLOAD_SIZE);
+    _cleanup_free_ void *{EXPECTED_BUF} = calloc(1, MAX_PAYLOAD_SIZE);
+    int rc = EXIT_FAILURE;
+
+    assert({REQ_BUF} != NULL);
+    assert({RSP_BUF} != NULL);
+    assert({EXPECTED_BUF} != NULL);
+    ctx = cxlmi_new_ctx(stdout, DEFAULT_LOGLEVEL);
+    assert(ctx != NULL);
+"""
+
+FOOTER = """
+cleanup:
+    cxlmi_close(ep);
+
+exit_free_ctx:
+    cxlmi_free_ctx(ctx);
+    if (rc != 0) {
+        fprintf(stdout, "Failed.\\n");
+    } else {
+        printf("Passed!\\n");
+    }
+    return rc;
+}
+"""
+
+G_COUNT = 1
+G_INDENT_LEVEL = 1
+ASSERT_INDENT = "    " * G_INDENT_LEVEL
+ASSERT_TYPE = "ASSERT_EQUAL"
+TUNNEL_INFO = "NULL"
+
+def get_expected_str():
+    return 'expected_' + str(G_COUNT)
+
+def get_actual_str():
+    return 'actual_' + str(G_COUNT)
+
+def get_req_str():
+    return 'request_' + str(G_COUNT)
+
+def generate_struct_body(element, indent_level=0, expected_name="expected_rsp", actual_name="actual", ptr=True):
+    indent = "    " * indent_level
+    struct_body = "{\n"
+    assertions = ""
+
+    for child in element:
+        field_name = child.tag
+        child_elements = list(child)
+        has_grandchildren = any(list(grandchild) for grandchild in child_elements)
+
+        # Skip flex array memebers, which can't be initialized in this format:
+        # struct X = {.field = Y, .field1 = Z}...
+        node_type = child.attrib.get('type', '').lower()
+        if node_type == 'flex':
+            # Flex array members must be handled separately
+            continue
+
+        # Case: Array of structs
+        if len(child_elements) > 0 and has_grandchildren:
+            struct_body += f"{indent}    .{field_name} = {{\n"
+            for i, entry in enumerate(child_elements):
+                nested_body, nested_assertions = generate_struct_body(
+                    entry,
+                    indent_level + 2,
+                    f"{expected_name}->{field_name}[{i}]",
+                    f"{actual_name}->{field_name}[{i}]",
+                    ptr=False
+                )
+                struct_body += f"{indent}        {nested_body},\n"
+                assertions += nested_assertions
+            struct_body += f"{indent}    }},\n"
+
+        # Case: Nested struct
+        elif len(child_elements) > 0:
+            nested_body, nested_assertions = generate_struct_body(
+                child,
+                indent_level + 1,
+                f"{expected_name}.{field_name}",
+                f"{actual_name}.{field_name}"
+            )
+            struct_body += f"{indent}    .{field_name} = {nested_body},\n"
+            assertions += nested_assertions
+
+        # Case: Scalar field
+        else:
+            if node_type == 'uuid':
+                # UUID() generated from 11 elements
+                uuid_elements = [e.strip for e in child.text.split(",")]
+                if len(uuid_elements) != 11:
+                    print(f"UUID WRONG USAGE: expected 11 elements, but got {len(uuid_elements)} while generating {child.tag}")
+                    continue
+
+                struct_body += f"{indent}    .{field_name} = UUID({child.text}),\n"
+                assertions += f"{ASSERT_INDENT}{ASSERT_TYPE}(memcmp({expected_name}->{field_name}, {actual_name}->{field_name}, 11), 0);\n"
+
+            else:
+                ref = '->' if ptr else '.'
+                struct_body += f"{indent}    .{field_name} = {child.text},\n"
+                assertions += f"{ASSERT_INDENT}{ASSERT_TYPE}({expected_name}{ref}{field_name}, {actual_name}{ref}{field_name});\n"
+
+    struct_body += f"{indent}}}"
+    return struct_body, assertions
+
+
+def generate_struct_code(var_name, struct_name, element, indent_level=0):
+    """
+    Recursively generate C code for requests/expected responses from the
+    given XML node.
+
+    Parameters:
+        - var_name: variable name for the request/response
+        (ex: req_1/expected_1/actual_1, etc.)
+        - struct_name: name of the struct (ex: cxlmi_cmd_XXX_req/cxlmi_cmd_XXX_rsp)
+        - element: corresponding XML node
+        - indent_level: indent level
+
+    Requests are generated in the following format. :
+        struct cxlmi_cmd_XXX_req expected_1 = {
+            .field_1 = value_1,
+            .field_2 = value_2,
+            ...
+        }
+    where value_1 and value_2 are read from the XML node.
+
+    Expected responses are generated similarly with their assertions:
+     struct cxlmi_cmd_XXX_rsp actual_1 = {
+        .field_1 = value_1,
+        ...
+     }
+
+     ASSERT_EQUAL(expected_1, actual_1, field_1);
+
+     OR if the response node is empty, return ""
+    """
+    if len(element) == 0:
+        return "", ""
+
+    struct_body, assertions = generate_struct_body(element,
+                                                   indent_level,
+                                                   expected_name=get_expected_str(),
+                                                   actual_name=get_actual_str())
+    code = f"*{var_name} = ({struct_name}) {struct_body};\n\n"
+    return code, assertions
+
+# Generate code for 1 command (create req payload, send the command, then check rsp payload)
+def generate_c_code(command, opcode_map):
+    opcode = command.attrib['opcode']
+    if opcode not in opcode_map:
+        return f'printf("Unknown opcode {opcode}\\n");'
+
+    mapping = opcode_map[opcode]
+    func = mapping['function']
+    request = command.find("request")
+    response = command.find("response")
+
+    req_str = get_req_str()
+    actual = get_actual_str()
+    expected = get_expected_str()
+
+    req_code, expected_rsp_code, assertions = "", "", ""
+
+    if request is not None:
+        req_struct = mapping['req']
+        # Generate req struct initialization. generate_struct_code always generates
+        # assertions, but ASSERT_EQUAL() don't apply to requests, so throw them away
+        req_code, _ = generate_struct_code(req_str,
+                                           req_struct,
+                                           request,
+                                           indent_level=G_INDENT_LEVEL)
+
+    if response is not None:
+        rsp_struct = mapping['rsp']
+        # Generate expected rsp struct initialization and checks
+        expected_rsp_code, assertions = generate_struct_code(expected,
+                                                         rsp_struct,
+                                                         response,
+                                                         indent_level=G_INDENT_LEVEL)
+
+    function_call = ""
+    cast_rsp = ""
+
+    # Handle case for different method signatures
+    if response is not None:
+        cast_rsp = f"{rsp_struct} *{actual} = ({rsp_struct} *) {RSP_BUF};"
+        if request is not None:
+            function_call = f"{func}(ep, {TUNNEL_INFO}, {req_str}, {actual})"
+        else:
+            function_call = f"{func}(ep, {TUNNEL_INFO}, {actual})"
+    elif request is not None:
+        function_call = f"{func}(ep, {TUNNEL_INFO}, {req_str})"
+    else:
+        function_call = f"{func}(ep, {TUNNEL_INFO})"
+
+    # Allocate and call the function
+    alloc_and_call = f"""
+    {cast_rsp}
+
+    rc = {function_call};
+    if (rc != 0) {{
+        fprintf(stdout, "Error: Function {func} ({opcode}h) returned non-zero rc: %d\\n", rc);
+        goto cleanup;
+    }}
+
+"""
+
+    # Cast request buf to req_type
+    if request is not None:
+        req_code = f"""
+    {req_struct} *{req_str} = ({req_struct} *){REQ_BUF};
+    {req_code}
+"""
+    # Cast expected buf to rsp_type
+    if response is not None:
+        expected_rsp_code = f"""
+    {rsp_struct} *{expected} = ({rsp_struct} *) {EXPECTED_BUF};
+    {expected_rsp_code}"""
+
+    return req_code + expected_rsp_code + alloc_and_call + assertions +"\n"
+
+def generate_ioctl_code(devname='mem0'):
+    return f"""
+    ep = cxlmi_open(ctx, "{devname}");
+    if (!ep) {{
+        fprintf(stdout, "Failed to open device %s\\n", "{devname}");
+        goto exit_free_ctx;
+    }}
+
+    printf("Opened endpoint on device %s\\n", "{devname}");
+
+    """
+
+def generate_mctp_code(nid=0, eid=0):
+    return f"""
+    ep = cxlmi_open_mctp(ctx, {nid}, {eid});
+
+    if (!ep) {{
+        printf("Failed to open MCTP EP with NID:EID =  %d:%d\\n", {nid}, {eid});
+        goto exit_free_ctx;
+    }}
+
+    printf("Opened MCTP EP with NID:EID =  %d:%d\\n", {nid}, {eid});
+
+    """
+
+# Generate test file for a single command
+def generate_test_file(output_file, command, suite_info, opcode_map):
+    if not opcode_map:
+        opcode_map = generate_default_opcode_map()
+
+    with open(output_file, 'w', newline='') as f:
+        # Write the prefix (C file header) to the file
+        f.write(PREFIX + "\n")
+
+        # Write the generated assert macro to the file with explicit newlines
+        f.write(ASSERT_MACRO)
+
+        f.write(MAIN)
+
+        if (ep := suite_info['mctp']) is not None:
+            nid, eid = ep
+            f.write(generate_mctp_code(nid, eid))
+        else:
+            f.write(generate_ioctl_code(suite_info['ioctl']))
+
+        # Generate and write the C code for each command
+        f.write(generate_c_code(command, opcode_map))
+        global G_COUNT
+        G_COUNT += 1
+
+        # Write the footer to the file
+        f.write(FOOTER)
+        G_COUNT = 1  # Reset the global counter for the next suites
+
+def load_xml(file_path):
+    tree = ET.parse(file_path)
+    return tree.getroot()
+
+def generate_build_file(build_file, test_file):
+    with open(build_file, 'a') as f:
+        f.write(f"""
+executable(
+    '{test_file[:-2]}',
+    ['{test_file}'],
+    dependencies: libcxlmi_dep,
+    include_directories: [inc]
+)
+""")
+
+if __name__ == "__main__":
+    # Default Generate All
+    if len(sys.argv) == 1:
+        print("Default: Generating All Test Code")
+        opcode_map = generate_default_opcode_map()
+        for suite, suite_info in suites.SUITES.items():
+            root = load_xml(CURR_DIR + '/' + suite_info['input'])
+
+            for command in root:
+                output = f'test-{command.get("opcode")}.c'
+                print(f'Generating {output}')
+                generate_test_file(output, command, suite_info, opcode_map)
+
+    elif len(sys.argv) == 2:
+        suite = sys.argv[1].upper()
+        suite_info = suites.SUITES[sys.argv[1].upper()]
+        print(f"Generating Test Code for Suite {suite}")
+        root = load_xml(CURR_DIR + '/' + suite_info['input'])
+        opcode_map = generate_default_opcode_map()
+
+        for command in root:
+            output = f'test-{command.get("opcode")}.c'
+            print(f'Generating {output}')
+            generate_test_file(output, command, suite_info, opcode_map)
+    else:
+        print("Usage: python generate_tests.py || python generate_tests.py <suite>")
+        sys.exit(1)

--- a/tests/qemu-tests/inputs/mailbox-commands.xml
+++ b/tests/qemu-tests/inputs/mailbox-commands.xml
@@ -1,0 +1,24 @@
+<root>
+    <command opcode="0500">
+        <request>
+            <count>64</count>
+            <starting_feature_index>0</starting_feature_index>
+        </request>
+        <response>
+            <num_supported_feature_entries>1</num_supported_feature_entries>
+            <device_supported_features>2</device_supported_features>
+            <!-- Skipping actual feature_data check -->
+        </response>
+    </command>
+    <command opcode="0501">
+        <request>
+            <feature_id type="uuid"> 0x96dad7d6, 0xfde8, 0x482b, 0xa7, 0x33, 0x75, 0x77, 0x4e, 0x06, 0xdb, 0x8a </feature_id>
+            <offset> 0 </offset>
+            <count> 64 </count>
+            <selection> 0 </selection>
+        </request>
+        <response>
+            <!-- Skipping actual feature_data check -->
+        </response>
+    </command>
+</root>

--- a/tests/qemu-tests/inputs/mctp-commands.xml
+++ b/tests/qemu-tests/inputs/mctp-commands.xml
@@ -1,0 +1,51 @@
+<root>
+    <command opcode="0001">
+        <response>
+            <vendor_id>32902</vendor_id>
+            <device_id >3475</device_id>
+            <subsys_vendor_id>6900</subsys_vendor_id>
+            <subsys_id>4352</subsys_id>
+            <serial_num>99</serial_num>
+            <max_msg_size>7</max_msg_size>
+            <component_type>3</component_type>
+        </response>
+    </command>
+    <command opcode="0004">
+        <request>
+            <limit>10</limit>
+        </request>
+        <response>
+            <limit>10</limit>
+        </response>
+    </command>
+    <command opcode="5601">
+        <request>
+            <host_id>0</host_id>
+            <region_cnt>2</region_cnt>
+            <start_region_id>0</start_region_id>
+        </request>
+        <response>
+            <host_id>0</host_id>
+            <num_regions>2</num_regions>
+            <regions_returned>2</regions_returned>
+            <region_configs>
+                <region_config>
+                    <base>0</base>
+                    <decode_len>2147483648</decode_len>
+                    <region_len>2147483648</region_len>
+                    <block_size>2097152 </block_size>
+                    <flags>0</flags>
+                    <sanitize_on_release>0</sanitize_on_release>
+                </region_config>
+                <region_config>
+                    <base>2147483648</base>
+                    <decode_len>2147483648</decode_len>
+                    <region_len>2147483648</region_len>
+                    <block_size>2097152 </block_size>
+                    <flags>0</flags>
+                    <sanitize_on_release>0</sanitize_on_release>
+                </region_config>
+            </region_configs>
+        </response>
+    </command>
+</root>

--- a/tests/qemu-tests/meson.build
+++ b/tests/qemu-tests/meson.build
@@ -1,0 +1,1 @@
+subdir('output')

--- a/tests/qemu-tests/parse_docs.py
+++ b/tests/qemu-tests/parse_docs.py
@@ -1,0 +1,99 @@
+import re
+import os
+
+CURR_DIR = os.path.dirname(os.path.abspath(__file__))
+
+def log_opcode_map(opcode_map):
+    path = os.path.join(CURR_DIR, 'output/opcode_map.txt')
+    with open(path, 'w') as f:
+        for opcode, info in opcode_map.items():
+            f.write(f"Opcode: {opcode}\n")
+            for key, value in info.items():
+                f.write(f"  {key}: {value}\n")
+            f.write("\n")
+
+def generate_default_opcode_map():
+    # Default paths
+    generic = os.path.join(CURR_DIR, "../../docs/Generic-Component-Commands.md")
+    memdev = os.path.join(CURR_DIR, "../../docs/Memory-Device-Commands.md")
+    fmapi = os.path.join(CURR_DIR, "../../docs/FM-API.md")
+    print("Generating opcode map using default paths...")
+    paths = [generic, memdev, fmapi]
+    opcode_map = {}
+
+    for path in paths:
+        opcode_map.update(parse_markdown_for_opcode_map(path))
+
+    return opcode_map
+
+def parse_markdown_for_opcode_map(file_path):
+
+    with open(file_path, 'r') as f:
+        md_content = f.read()
+
+    opcode_map = {}
+    current_opcode = None
+    current_function = None
+    current_req = None
+    current_rsp = None
+
+    # Normalize newlines
+    lines = md_content.splitlines()
+    for i, line in enumerate(lines):
+        # Match headers like ## Identify (0001h)
+        m = re.match(r'## .+\((\w{4})h\)', line)
+        if m:
+            current_opcode = m.group(1).lower()
+            current_function = None
+            current_req = None
+            current_rsp = None
+            continue
+
+        # Match C function signature and extract function name and param types
+        if line.strip().startswith("int cxlmi_cmd"):
+            func_line = line.strip().strip('`').strip(';')
+            func_match = re.match(r'int (\w+)\s*\(.*', func_line)
+            if func_match:
+                current_function = func_match.group(1)
+
+                # Check next few lines for *in or *ret to determine req/rsp
+                for offset in range(0, 10):
+                    if i + offset >= len(lines):
+                        break
+                    l = lines[i + offset]
+                    struct_match = re.search(r'struct\s+(\w+)\s*\*\s*(in|ret)', l)
+                    if struct_match:
+                        struct_name = struct_match.group(1)
+                        direction = struct_match.group(2)
+                        if direction == 'in':
+                            current_req = f'struct {struct_name}'
+                        elif direction == 'ret':
+                            current_rsp = f'struct {struct_name}'
+
+                suite = ""
+                match os.path.basename(file_path):
+                    case "Generic-Component-Commands.md":
+                        suite = "GENERIC"
+                    case "FM-API.md":
+                        suite = 'FMAPI'
+                    case "Memory-Device-Commands.md":
+                        suite = "MEMDEV"
+                    case "Vendor-Specific-Commands.md":
+                        suite = "VENDOR"
+                    case _:
+                        suite = "UNKNOWN"
+                if current_opcode:
+                    opcode_map[current_opcode] = {
+                        'function': current_function,
+                        'req': current_req,
+                        'rsp': current_rsp,
+                        'suite': suite
+                    }
+
+    return opcode_map
+
+def main():
+    log_opcode_map(generate_default_opcode_map())
+
+if __name__ == "__main__":
+    main()

--- a/tests/qemu-tests/run_tests.py
+++ b/tests/qemu-tests/run_tests.py
@@ -1,0 +1,312 @@
+import sys
+import os
+import shutil
+import argparse
+import subprocess
+import time
+import xml.etree.ElementTree as ET
+from collections import deque
+from suites import SUITES
+from parse_docs import generate_default_opcode_map, log_opcode_map
+from generate_tests import generate_test_file, generate_build_file, load_xml
+
+# Global Variables
+CURR_DIR = os.path.dirname(os.path.abspath(__file__))
+REPO_ROOT = os.path.join(CURR_DIR, '../', '../')
+VM_PORT = 2025   # Must match .vars.config used by cxl-test-tool
+VM_USER = 'root'
+VM_HOSTNAME = 'localhost'
+QEMU_LOG = os.path.join(os.path.expanduser("~"), 'logs', 'qemu0.log')
+opcode_map = {}
+
+# Create output dir for generating test code
+os.makedirs(CURR_DIR + '/output', exist_ok=True)
+# Parse opcode map
+opcode_map = generate_default_opcode_map()
+log_opcode_map(opcode_map)
+
+def monitor(file_path):
+    """Generator that yields new lines as they are written to the file."""
+    with open(file_path, 'r', encoding='utf-8', errors='replace') as f:
+        f.seek(0, os.SEEK_END)  # Move to EOF
+        while True:
+            line = f.readline()
+            if line:
+                yield line
+            else:
+                time.sleep(0.1)
+                yield None
+
+def wait_for_boot(log_path, timeout=90):
+    """Wait until the guest OS shows the login prompt."""
+    print(f"🟡 Waiting for QEMU boot in {log_path} (timeout: {timeout}s)...")
+    start = time.time()
+    for line in monitor(log_path):
+        if line and "login:" in line:
+            print(f"✅ QEMU Guest Booted in {time.time() - start} seconds!")
+            return
+        if time.time() - start > timeout:
+            print("❌ Timeout waiting for QEMU guest to boot.")
+            raise TimeoutError("Boot detection timed out.")
+
+def wait_for_shutdown(log_path, timeout=60):
+    """Wait until the guest shuts down (power off message)."""
+    print('Shutting down VM...')
+    run_on_vm('sync && poweroff')
+    print(f"🟡 Waiting for QEMU shutdown in {log_path} (timeout: {timeout}s)...")
+    start = time.time()
+
+    # Check last 10 lines of qemu_log for shut down before scanning in new lines
+    last_lines = ""
+    with open(log_path, 'r') as f:
+        last_lines =  list(deque(f, maxlen=10))
+
+    if any("reboot: Power down" in line for line in last_lines):
+        print(f"✅ QEMU Guest Shut Down in {time.time() - start} seconds!")
+        return
+
+    # Otherwise, wait for shut down message
+    for line in monitor(log_path):
+        if line:
+            print(line)
+        if line and "reboot: Power down" in line:
+            print(f"✅ QEMU Guest Shut Down in {time.time() - start} seconds!")
+            return
+        if time.time() - start > timeout:
+            print("❌ Timeout waiting for QEMU shutdown.")
+            raise TimeoutError("Shutdown detection timed out.")
+
+def run_shell_cmd(cmd:str, echo=True):
+    if echo:
+        print(cmd)
+    output = subprocess.getoutput(cmd)
+    if echo:
+        print(output)
+    return output
+
+def run_on_vm(cmd:str):
+    return run_shell_cmd(f"cxl-tool --cmd '{cmd}'")
+
+def install_libcxlmi_on_vm(target_dir="/tmp/libcxlmi"):
+    print('Copy libcxlmi to VM')
+    cmd = f"""rsync -av -e 'ssh -p {VM_PORT}' \
+          --exclude='.git/' \
+          --exclude='build/' \
+          "{REPO_ROOT}" {VM_USER}@{VM_HOSTNAME}:{target_dir}"""
+    run_shell_cmd(cmd)
+    print('-------------------------------------------------')
+
+    print('Compile libcxlmi')
+    cmd="cd %s; meson setup -Dlibdbus=enabled -Dmctpd=codeconstruct build; meson compile -C build;"%target_dir
+    run_on_vm(cmd)
+    cmd=f"ls -l {target_dir}/build/tests/qemu-tests/output"
+    run_on_vm(cmd)
+
+def start_vm(suite):
+    # Start VM
+    print(f"STARTING VM: {suite}")
+    topo = suite['qemu_str']
+    run_shell_cmd(f'cxl-tool --run -A tcg --raw -T \'{topo}\'')
+
+    try:
+        wait_for_boot(QEMU_LOG)
+    except TimeoutError as e:
+        print(f"⛔ {e}")
+        sys.exit(1)
+
+    print('-------------------------------------------------')
+
+    # Set up MCTP
+    if suite["mctp"] is not None:
+        run_shell_cmd("cxl-tool --setup-mctp-usb")
+        print('-------------------------------------------------')
+
+    print("Loading Drivers")
+    run_shell_cmd("cxl-tool --load-drv")
+    print('-------------------------------------------------')
+
+    # Show topo info as debug output
+    run_on_vm("cxl list")
+    print('-------------------------------------------------')
+
+    print('Install necessary packages on VM')
+    run_on_vm('apt-get update && apt-get install -y rsync')
+    run_on_vm('apt-get install -y meson libdbus-1-dev git cmake locales')
+
+    # Copy current libcxlmi repo to VM and compile
+    libcxlmi_path = "/tmp/libcxlmi"
+    install_libcxlmi_on_vm(libcxlmi_path)
+    print('-------------------------------------------------')
+
+def execute_test(opcode, test_file, results_file):
+    # Execute tests and capture output
+    with open(results_file, 'w') as f:
+        # Execute test file
+        test_executable = f'/tmp/libcxlmi/build/tests/qemu-tests/output/{test_file[:-2]}'
+        results = run_on_vm(test_executable)
+        f.write(results)
+        if results.splitlines()[-1] == "Passed!":
+            print(f"Test {opcode} passed.")
+            return 0
+        else:
+            print(f"Test {opcode} failed. Check {results_file} for details.")
+            return -1
+
+def run_tests(test_infos, topo_info) -> tuple[int, int]:
+    """
+        Takes a list of opcodes, generates test files for them, starts a VM, and
+        executes them on the VM.
+
+        Returns: (num_tests_passed, total_passed)
+    """
+    # maps opcode to its test_file and log file
+    file_info = {}
+    num_passed = 0
+    total_tests = 0
+    build_file = os.path.join(CURR_DIR, 'output/', 'meson.build')
+
+    # Clear build file from previous run
+    with open(build_file, 'w') as f:
+        pass
+
+    for opcode, command_xml in test_infos.items():
+        file_info[opcode] = {}
+        info = file_info[opcode]
+
+        test_file = 'test-' + f'{opcode}' + '.c'
+        info['test_file'] = test_file
+        test_file_path = os.path.join(CURR_DIR, 'output/', test_file)
+        results_file = os.path.join(CURR_DIR, 'output/', test_file[:-2] + '-results.txt')
+        info['results_file'] = results_file
+
+        generate_test_file(test_file_path, command_xml, topo_info, opcode_map)
+
+        generate_build_file(build_file, test_file)
+        total_tests += 1
+
+        print(f"Test file has been written to {test_file_path}")
+
+    run_shell_cmd(f'cat {build_file}')
+    if start_vm(topo_info):
+        print("Startup failed. Test not run.")
+        return (-1, total_tests)
+
+    for opcode, files in file_info.items():
+        test_file = files['test_file']
+        results_file = files['results_file']
+        if execute_test(opcode, test_file, results_file) == 0:
+            num_passed += 1
+
+    return (num_passed, total_tests)
+
+def run_test(opcode) -> tuple[int, int]:
+    suite_name = opcode_map[opcode]['suite']
+    topo_info = SUITES[suite_name]
+    print(f"Opcode {opcode} belongs to suite {suite_name}")
+
+    input_file = os.path.join(CURR_DIR, topo_info['input'])
+    root = load_xml(input_file)
+    command_xml = next((child for child in root if child.attrib.get('opcode') == opcode), None)
+
+    num_passed, _ = run_tests({opcode:command_xml}, topo_info)
+
+    if num_passed != 1:
+        print(f'TEST {opcode} FAILED')
+
+    return (num_passed, 1)
+
+def run_suite(suite) -> tuple[int, int]:
+    """
+        Takes a suite defined in topo.py and runs all tests defined for the suite
+
+        Returns: (num_tests_passed, total_passed)
+    """
+    topo_info = SUITES[suite]
+    input_file = os.path.join(CURR_DIR, topo_info['input'])
+    root = load_xml(input_file)
+    test_infos = {}
+
+    print('-------------------------------------------------')
+    print(f'RUNNING SUITE {suite}')
+
+    for command in root:
+        test_infos[command.attrib.get('opcode')] = command
+
+    (num_passed, total_tests) = run_tests(test_infos, topo_info)
+
+    # Print results
+    print('-------------------------------------------------')
+    if num_passed < 0:
+        print(f'SUITE {suite} FAILED TO RUN')
+
+        # Set to 0 when printing results
+        num_passed = 0
+    elif num_passed != total_tests:
+        print(f'SUITE {suite} RESULTS: {num_passed} tests passed out of {total_tests}')
+    else:
+        print(f'SUITE {suite} ALL TESTS PASSED: {num_passed} / {total_tests}')
+
+    # Shut down VM and clean up
+    try:
+        wait_for_shutdown(QEMU_LOG)
+        time.sleep(5)
+    except TimeoutError as e:
+        print(f"⛔ {e}")
+        sys.exit(1)
+
+    return (num_passed, total_tests)
+
+def run_all():
+    print("RUN_ALL")
+    num_passed = 0
+    total_tests = 0
+
+    for suite, _ in SUITES.items():
+        (suite_num_passed, suite_num_tests) = run_suite(suite)
+        num_passed += suite_num_passed
+        total_tests += suite_num_tests
+
+    print('-------------------------------------------------')
+    if num_passed != total_tests:
+        print(f'AGGREGATE RESULTS: {num_passed} tests passed out of {total_tests}')
+    else:
+        print(f'ALL TESTS PASSED: {num_passed} / {total_tests}')
+    return (num_passed, total_tests)
+
+def clear_subdir(path):
+    for filename in os.listdir(path):
+        full_path = os.path.join(path, filename)
+        try:
+            if os.path.isfile(full_path) or os.path.islink(full_path):
+                os.unlink(full_path)  # remove file or symlink
+            elif os.path.isdir(full_path):
+                shutil.rmtree(full_path)  # remove directory recursively
+        except Exception as e:
+            print(f'Failed to delete {full_path}. Reason: {e}')
+
+def add_args(parser):
+    parser.add_argument('-t', '--test', type=str, required=False, help='opcode of the test')
+    parser.add_argument('-s', '--suite', type=str, required=False, help='test suite (defined in topo.py)')
+
+def main():
+    # Parse args
+    parser = argparse.ArgumentParser()
+    add_args(parser)
+    args = parser.parse_args()
+
+    num_passed = 0
+    total_tests = 0
+
+    if args.test:
+        num_passed, total_tests = run_test(args.test)
+    elif args.suite:
+        num_passed, total_tests = run_suite(args.suite)
+    else:
+        num_passed, total_tests = run_all()
+
+    if num_passed != total_tests:
+        return -1
+    return 0
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/qemu-tests/suites.py
+++ b/tests/qemu-tests/suites.py
@@ -1,0 +1,50 @@
+# <--------------- XML files defining input ------------------------------>
+MAILBOX_COMMANDS = "inputs/mailbox-commands.xml"
+MCTP_COMMANDS = "inputs/mctp-commands.xml"
+
+# <--------------- Supported Topologies ------------------------------>
+
+# 1 direct-attached T3 device
+# NO MCTP
+DIRECT_T3 = "-object memory-backend-file,id=cxl-mem1,share=on,mem-path=/tmp/cxltest.raw,size=512M \
+-object memory-backend-file,id=cxl-lsa1,share=on,mem-path=/tmp/lsa.raw,size=1M \
+-device pxb-cxl,bus_nr=12,bus=pcie.0,id=cxl.1,hdm_for_passthrough=true \
+-device cxl-rp,port=0,bus=cxl.1,id=root_port13,chassis=0,slot=2 \
+-device cxl-type3,bus=root_port13,memdev=cxl-mem1,lsa=cxl-lsa1,id=cxl-pmem0,sn=0xabcd \
+-M cxl-fmw.0.targets.0=cxl.1,cxl-fmw.0.size=4G,cxl-fmw.0.interleave-granularity=8k"
+
+# 1 DCD with 2 DC regions direct attached to the host
+# and with 1 MCTP USB bus
+FM_DCD = "-device usb-ehci,id=ehci \
+     -object memory-backend-file,id=cxl-mem1,mem-path=/tmp/t3_cxl1.raw,size=4G \
+     -object memory-backend-file,id=cxl-lsa1,mem-path=/tmp/t3_lsa1.raw,size=1M \
+     -device pxb-cxl,bus_nr=12,bus=pcie.0,id=cxl.1,hdm_for_passthrough=true \
+     -device cxl-rp,port=0,bus=cxl.1,id=cxl_rp_port0,chassis=0,slot=2 \
+     -device cxl-upstream,port=2,sn=1234,bus=cxl_rp_port0,id=us0,addr=0.0,multifunction=on, \
+     -device cxl-switch-mailbox-cci,bus=cxl_rp_port0,addr=0.1,target=us0 \
+     -device cxl-downstream,port=0,bus=us0,id=swport0,chassis=0,slot=4 \
+     -device cxl-type3,bus=swport0,volatile-dc-memdev=cxl-mem1,id=cxl-dcd0,lsa=cxl-lsa1,num-dc-regions=2,sn=99 \
+     -device usb-cxl-mctp,bus=ehci.0,id=usb0,target=us0 \
+     -device usb-cxl-mctp,bus=ehci.0,id=usb1,target=cxl-dcd0\
+     -machine cxl-fmw.0.targets.0=cxl.1,cxl-fmw.0.size=4G,cxl-fmw.0.interleave-granularity=1k"
+
+# <--------------- Topo Map ------------------------------>
+"""
+Map of topology to:
+- input: path to XML file defining commands to test on it
+- qemu_str: its QEMU string
+- mctp: nid:eid tuple of EP to open
+- ioctl: name of device if ioctl EP opened
+"""
+SUITES = {
+    "MAILBOX" : {
+        "input": MAILBOX_COMMANDS,
+        "qemu_str" : DIRECT_T3,
+        "mctp" : None,
+        "ioctl" : "mem0"},
+    "MCTP" : {
+        "input": MCTP_COMMANDS,
+        "qemu_str" : FM_DCD,
+        "mctp" : (1, 8),
+        "ioctl" : "mem0"},
+}


### PR DESCRIPTION
Set up framework for testing libcxlmi on QEMU VMs.

Depends on:
- [mctpd v2 support](https://github.com/computexpresslink/libcxlmi/pull/35/commits) to enable setting up MCTP/USB endpoints.
- [Feature Command Set](https://github.com/computexpresslink/libcxlmi/pull/29) because the feature command set is included in the test cases

The tests will fail if these are not added yet.

### File Breakdown
- `mailbox-commands.xml`: defines test cases for mailbox commands
- `mctp-commands.xml`: defines test cases for MCTP commands
- `suites.py`: organizes test cases into suites, currently just organized by which XML file they are defined in and the topology info for each suite.
- `parse_docs.py`: Util file for parsing `docs/FM-API.md`, `docs/Memory-Device-Commands.md`, etc. to map each opcode to its req/rsp struct and function signature. This mapping is used to auto-generate test files
- `generate_tests.py`: Generates test code, one file per opcode as `test-[opcode].c`
- `run_tests.py`: Uses `cxl-test-tool` to start VMs, run tests, and collect test pass/fail data.
- `.github/workflows/run-tests.yml`: Starts container with Docker image, clones `cxl-test-tool`, sets up SSH connection for VM, then calls `run_tests.py` to run all tests and collects logging information.
- [README](https://github.com/anisa-su993/libcxlmi/blob/main/tests/qemu-tests/README.md): for more details

### Testing
Tested on GH Runners by triggering workflow runs on my fork:
https://github.com/anisa-su993/libcxlmi/actions/runs/16658512879

<img width="2188" height="1270" alt="image" src="https://github.com/user-attachments/assets/78d3c35e-ae96-4993-9434-47eae435f0b9" />

