### PR TITLE
Fix Req Payload Allocation for Transfer FW & Memdev Set LSA

### DIFF
--- a/docs/Generic-Component-Commands.md
+++ b/docs/Generic-Component-Commands.md
@@ -367,7 +367,8 @@ Command name:
    ```C
 int cxlmi_cmd_transfer_fw(struct cxlmi_endpoint *ep,
 			  struct cxlmi_tunnel_info *ti,
-			  struct cxlmi_cmd_transfer_fw *in);
+			  struct cxlmi_cmd_transfer_fw *in,
+              size_t data_sz);
    ```
 
 ## Activate FW (0202h)

--- a/docs/Memory-Device-Commands.md
+++ b/docs/Memory-Device-Commands.md
@@ -164,7 +164,8 @@ Command name:
    ```C
 int cxlmi_cmd_memdev_set_lsa(struct cxlmi_endpoint *ep,
 				 struct cxlmi_tunnel_info *ti,
-				 struct cxlmi_cmd_memdev_set_lsa *in);
+				 struct cxlmi_cmd_memdev_set_lsa *in,
+                 size_t data_sz);
    ```
 
 # Health Info and Alerts (42h)

--- a/src/cxlmi/commands.c
+++ b/src/cxlmi/commands.c
@@ -1099,12 +1099,13 @@ CXLMI_EXPORT int cxlmi_cmd_memdev_get_lsa(struct cxlmi_endpoint *ep,
 
 CXLMI_EXPORT int cxlmi_cmd_memdev_set_lsa(struct cxlmi_endpoint *ep,
 					  struct cxlmi_tunnel_info *ti,
-					  struct cxlmi_cmd_memdev_set_lsa *in)
+					  struct cxlmi_cmd_memdev_set_lsa *in,
+                      size_t data_sz)
 {
 	struct cxlmi_cmd_memdev_set_lsa  *req_pl;
 	_cleanup_free_ struct cxlmi_cci_msg *req = NULL;
 	struct cxlmi_cci_msg rsp;
-	size_t req_sz, data_sz = struct_size(in, data, 0);
+	size_t req_sz;
 
 	req_sz = sizeof(*req) + data_sz + sizeof(*in);
 	req = calloc(1, req_sz);

--- a/src/cxlmi/commands.c
+++ b/src/cxlmi/commands.c
@@ -446,12 +446,13 @@ CXLMI_EXPORT int cxlmi_cmd_get_fw_info(struct cxlmi_endpoint *ep,
 
 CXLMI_EXPORT int cxlmi_cmd_transfer_fw(struct cxlmi_endpoint *ep,
 				       struct cxlmi_tunnel_info *ti,
-				       struct cxlmi_cmd_transfer_fw *in)
+				       struct cxlmi_cmd_transfer_fw *in,
+                       size_t data_sz)
 {
 	struct cxlmi_cmd_transfer_fw *req_pl;
 	_cleanup_free_ struct cxlmi_cci_msg *req = NULL;
 	struct cxlmi_cci_msg rsp;
-	ssize_t req_sz, data_sz = struct_size(in, data, 0);
+	ssize_t req_sz;
 	int rc = -1;
 
 	req_sz = sizeof(*req_pl) + data_sz + sizeof(*req);

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -433,7 +433,8 @@ int cxlmi_cmd_get_fw_info(struct cxlmi_endpoint *ep,
 			  struct cxlmi_cmd_get_fw_info *out);
 int cxlmi_cmd_transfer_fw(struct cxlmi_endpoint *ep,
 			  struct cxlmi_tunnel_info *ti,
-			  struct cxlmi_cmd_transfer_fw *in);
+			  struct cxlmi_cmd_transfer_fw *in,
+              size_t data_sz);
 int cxlmi_cmd_activate_fw(struct cxlmi_endpoint *ep,
 			  struct cxlmi_tunnel_info *ti,
 			  struct cxlmi_cmd_activate_fw *in);

--- a/src/libcxlmi.h
+++ b/src/libcxlmi.h
@@ -503,7 +503,8 @@ int cxlmi_cmd_memdev_get_lsa(struct cxlmi_endpoint *ep,
 			     struct cxlmi_cmd_memdev_get_lsa *ret);
 int cxlmi_cmd_memdev_set_lsa(struct cxlmi_endpoint *ep,
 			     struct cxlmi_tunnel_info *ti,
-			     struct cxlmi_cmd_memdev_set_lsa *in);
+			     struct cxlmi_cmd_memdev_set_lsa *in,
+                 size_t data_sz);
 
 int cxlmi_cmd_memdev_get_health_info(struct cxlmi_endpoint *ep,
 			     struct cxlmi_tunnel_info *ti,


### PR DESCRIPTION
Bug was found in request payload allocation size for commands with variable data size payloads.

These 2 commits fixes the bug by adding data size as an input parameter.

Previously, the transfer_fw command looked like the below (with added print statements)
```
CXLMI_EXPORT int cxlmi_cmd_transfer_fw(struct cxlmi_endpoint *ep, 
                                       struct cxlmi_tunnel_info *ti, 
                                       struct cxlmi_cmd_transfer_fw *in) 
{ 
        struct cxlmi_cmd_transfer_fw *req_pl; 
        _cleanup_free_ struct cxlmi_cci_msg *req = NULL; 
        struct cxlmi_cci_msg rsp; 
        ssize_t req_sz, data_sz = struct_size(in, data, 0); 
        int rc = -1; 
 
        printf("Transfer FW Data Size: %lu\n", data_sz); 
        printf("sizeof(*in): %lu\n", sizeof(*in)); 
        req_sz = sizeof(*req_pl) + data_sz + sizeof(*req); 
 
        printf("req_sz: %lu\n", req_sz); 
        req = calloc(1, req_sz); 
        if (!req) 
                return -1; 
...
```
When tested with a short test program:
```
struct cxlmi_cmd_transfer_fw *transfer_fw = calloc(1, sizeof(*transfer_fw) + 27);

 rc =cxlmi_cmd_transfer_fw(ep, NULL, transfer_fw);
```
The output was:
```
Transfer FW Data Size: 128
sizeof(*in): 128
req_sz: 268
```
This showed that the req_payload size, which should have been the size of the request header + the size of the other fields in the transfer_fw struct + 27, but was instead the size of the request header + 2 * (size of the other fields in the transfer_fw struct).