### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -1,4 +1,6 @@
 name: Coverity Scan
+permissions:
+  contents: read
 
 on:
   schedule:


### PR DESCRIPTION
Potential fix for [https://github.com/computexpresslink/libcxlmi/security/code-scanning/1](https://github.com/computexpresslink/libcxlmi/security/code-scanning/1)

To fix this security issue, add a `permissions` block to the workflow YAML. This block should be set at the highest appropriate level—either directly under the workflow root or under the specific job—which restricts the GITHUB_TOKEN to only the permissions required. For this workflow, `contents: read` is likely sufficient, as it allows read access to repository contents without granting write access. Place the `permissions` block just after the workflow `name`, and before (or after) the `on:` key, to apply it globally to all jobs unless a job-level override is needed. No additional external libraries or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
