### PR TITLE
cxlmi.c: fixup cxlmi_cmd_is_fmapi

### DIFF
--- a/src/cxlmi/cxlmi.c
+++ b/src/cxlmi/cxlmi.c
@@ -1068,6 +1068,7 @@ static bool cxlmi_cmd_is_fmapi(int cmdset)
 {
 	switch(cmdset) {
 	case PHYSICAL_SWITCH:
+        case VIRTUAL_SWITCH:
 	case MLD_PORT:
 	case MHD:
 	case DCD_MANAGEMENT:


### PR DESCRIPTION
Get VCS info command (5200) (and others in this command set) are not issued correctly. Currently issued as
a CCI command rather than an FMAPI command. Issue VIRTUAL_SWITCH commands as MCTP_TYPE_CXL_FMAPI rather than MCTP_TYPE_CXL_CCI.

fixes: 2f14ae0