### PR TITLE
examples: fix static analyzer warning in fmapi-mctp

### DIFF
--- a/examples/fmapi-mctp.c
+++ b/examples/fmapi-mctp.c
@@ -284,7 +284,7 @@ static int split_cmd_to_argv(char* cmd, char*** argvp)
         if (!argv[argc]) {
             printf("Failed to allocate argv.\n");
             for (i = 0; i < argc; i++) {
-                free(argv[argc]);
+                free(argv[i]);
             }
             free(cmd_cpy);
             free(argv);
@@ -298,6 +298,12 @@ static int split_cmd_to_argv(char* cmd, char*** argvp)
 
     argv[argc] = NULL;
     free(cmd_cpy);
+
+    if (argc == 0) {
+        free(argv);
+        return -1;
+    }
+
     *argvp = argv;
     return argc;
 }


### PR DESCRIPTION
1. When the command string contains no tokens, split_cmd_to_argv() assigns the allocated argv to *argvp and returns 0. The caller treats that as a failure and returns without freeing, which clang reports as a potential leak of 'argv'. Free argv and return -1 instead.

2. fix loop in split_cmd_to_argv()

Cleanup loop originally freed "argv[argc]" argc times. Should free argv[i] instead.

	printf("Failed to allocate argv.\n");
            for (i = 0; i < argc; i++) {
                free(argv[argc]);
            }